### PR TITLE
feat: mobile digital noticeboard

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -40,6 +40,15 @@ import type * as maintenanceDefinitions_web_queries_getTechnicians from "../main
 import type * as maintenanceDefinitions_web_queries_getUnitsByProperty from "../maintenanceDefinitions/web/queries/getUnitsByProperty.js";
 import type * as noticeboard from "../noticeboard.js";
 import type * as noticeboardDefinitions_index from "../noticeboardDefinitions/index.js";
+import type * as noticeboardDefinitions_mobile_mutations_acknowledgeNotice from "../noticeboardDefinitions/mobile/mutations/acknowledgeNotice.js";
+import type * as noticeboardDefinitions_mobile_mutations_addEventToCalendar from "../noticeboardDefinitions/mobile/mutations/addEventToCalendar.js";
+import type * as noticeboardDefinitions_mobile_mutations_sendFeedback from "../noticeboardDefinitions/mobile/mutations/sendFeedback.js";
+import type * as noticeboardDefinitions_mobile_mutations_submitPollResponse from "../noticeboardDefinitions/mobile/mutations/submitPollResponse.js";
+import type * as noticeboardDefinitions_mobile_queries_getActivePolls from "../noticeboardDefinitions/mobile/queries/getActivePolls.js";
+import type * as noticeboardDefinitions_mobile_queries_getCommunityNews from "../noticeboardDefinitions/mobile/queries/getCommunityNews.js";
+import type * as noticeboardDefinitions_mobile_queries_getEvents from "../noticeboardDefinitions/mobile/queries/getEvents.js";
+import type * as noticeboardDefinitions_mobile_queries_getNoticeById from "../noticeboardDefinitions/mobile/queries/getNoticeById.js";
+import type * as noticeboardDefinitions_mobile_queries_getNotices from "../noticeboardDefinitions/mobile/queries/getNotices.js";
 import type * as noticeboardDefinitions_web_mutations_acknowledgeNotice from "../noticeboardDefinitions/web/mutations/acknowledgeNotice.js";
 import type * as noticeboardDefinitions_web_mutations_createNotice from "../noticeboardDefinitions/web/mutations/createNotice.js";
 import type * as noticeboardDefinitions_web_mutations_deleteNotice from "../noticeboardDefinitions/web/mutations/deleteNotice.js";
@@ -59,6 +68,7 @@ import type * as propertyDefinitions_mobile_index from "../propertyDefinitions/m
 import type * as propertyDefinitions_mobile_queries_getMyProperties from "../propertyDefinitions/mobile/queries/getMyProperties.js";
 import type * as propertyDefinitions_mobile_queries_getProperties from "../propertyDefinitions/mobile/queries/getProperties.js";
 import type * as propertyDefinitions_mobile_queries_index from "../propertyDefinitions/mobile/queries/index.js";
+import type * as seeders_notice from "../seeders/notice.js";
 import type * as seeders_seed from "../seeders/seed.js";
 import type * as unit from "../unit.js";
 import type * as unitDefinitions_index from "../unitDefinitions/index.js";
@@ -125,6 +135,15 @@ declare const fullApi: ApiFromModules<{
   "maintenanceDefinitions/web/queries/getUnitsByProperty": typeof maintenanceDefinitions_web_queries_getUnitsByProperty;
   noticeboard: typeof noticeboard;
   "noticeboardDefinitions/index": typeof noticeboardDefinitions_index;
+  "noticeboardDefinitions/mobile/mutations/acknowledgeNotice": typeof noticeboardDefinitions_mobile_mutations_acknowledgeNotice;
+  "noticeboardDefinitions/mobile/mutations/addEventToCalendar": typeof noticeboardDefinitions_mobile_mutations_addEventToCalendar;
+  "noticeboardDefinitions/mobile/mutations/sendFeedback": typeof noticeboardDefinitions_mobile_mutations_sendFeedback;
+  "noticeboardDefinitions/mobile/mutations/submitPollResponse": typeof noticeboardDefinitions_mobile_mutations_submitPollResponse;
+  "noticeboardDefinitions/mobile/queries/getActivePolls": typeof noticeboardDefinitions_mobile_queries_getActivePolls;
+  "noticeboardDefinitions/mobile/queries/getCommunityNews": typeof noticeboardDefinitions_mobile_queries_getCommunityNews;
+  "noticeboardDefinitions/mobile/queries/getEvents": typeof noticeboardDefinitions_mobile_queries_getEvents;
+  "noticeboardDefinitions/mobile/queries/getNoticeById": typeof noticeboardDefinitions_mobile_queries_getNoticeById;
+  "noticeboardDefinitions/mobile/queries/getNotices": typeof noticeboardDefinitions_mobile_queries_getNotices;
   "noticeboardDefinitions/web/mutations/acknowledgeNotice": typeof noticeboardDefinitions_web_mutations_acknowledgeNotice;
   "noticeboardDefinitions/web/mutations/createNotice": typeof noticeboardDefinitions_web_mutations_createNotice;
   "noticeboardDefinitions/web/mutations/deleteNotice": typeof noticeboardDefinitions_web_mutations_deleteNotice;
@@ -144,6 +163,7 @@ declare const fullApi: ApiFromModules<{
   "propertyDefinitions/mobile/queries/getMyProperties": typeof propertyDefinitions_mobile_queries_getMyProperties;
   "propertyDefinitions/mobile/queries/getProperties": typeof propertyDefinitions_mobile_queries_getProperties;
   "propertyDefinitions/mobile/queries/index": typeof propertyDefinitions_mobile_queries_index;
+  "seeders/notice": typeof seeders_notice;
   "seeders/seed": typeof seeders_seed;
   unit: typeof unit;
   "unitDefinitions/index": typeof unitDefinitions_index;

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -31,8 +31,6 @@ import {
   bulkUpdateStatusHandler,
 } from './maintenanceDefinitions/index';
 
-import { seedDatabase } from './seeders/seed';
-
 // Queries
 export const getMaintenanceRequests = query({
   args: getMaintenanceRequestsArgs,
@@ -96,8 +94,6 @@ export const bulkUpdateStatus = mutation({
   args: bulkUpdateStatusArgs,
   handler: bulkUpdateStatusHandler,
 });
-
-export { seedDatabase };
 import {
   createRequestArgs,
   createRequestHandler,

--- a/convex/noticeboard.ts
+++ b/convex/noticeboard.ts
@@ -39,6 +39,33 @@ import {
   acknowledgeNoticeArgs,
   acknowledgeNoticeHandler,
   acknowledgeNoticeReturns,
+  getNoticesArgs as mobileGetNoticesArgs,
+  getNoticesHandler as mobileGetNoticesHandler,
+  getNoticesReturns as mobileGetNoticesReturns,
+  getNoticeByIdArgs as mobileGetNoticeByIdArgs,
+  getNoticeByIdHandler as mobileGetNoticeByIdHandler,
+  getNoticeByIdReturns as mobileGetNoticeByIdReturns,
+  acknowledgeNoticeArgs as mobileAcknowledgeNoticeArgs,
+  acknowledgeNoticeHandler as mobileAcknowledgeNoticeHandler,
+  acknowledgeNoticeReturns as mobileAcknowledgeNoticeReturns,
+  getEventsArgs as mobileGetEventsArgs,
+  getEventsHandler as mobileGetEventsHandler,
+  getEventsReturns as mobileGetEventsReturns,
+  addEventToCalendarArgs as mobileAddEventToCalendarArgs,
+  addEventToCalendarHandler as mobileAddEventToCalendarHandler,
+  addEventToCalendarReturns as mobileAddEventToCalendarReturns,
+  getActivePollsArgs as mobileGetActivePollsArgs,
+  getActivePollsHandler as mobileGetActivePollsHandler,
+  getActivePollsReturns as mobileGetActivePollsReturns,
+  submitPollResponseArgs as mobileSubmitPollResponseArgs,
+  submitPollResponseHandler as mobileSubmitPollResponseHandler,
+  submitPollResponseReturns as mobileSubmitPollResponseReturns,
+  sendFeedbackArgs as mobileSendFeedbackArgs,
+  sendFeedbackHandler as mobileSendFeedbackHandler,
+  sendFeedbackReturns as mobileSendFeedbackReturns,
+  getCommunityNewsArgs as mobileGetCommunityNewsArgs,
+  getCommunityNewsHandler as mobileGetCommunityNewsHandler,
+  getCommunityNewsReturns as mobileGetCommunityNewsReturns,
 } from './noticeboardDefinitions/index';
 
 // Queries
@@ -119,4 +146,59 @@ export const acknowledgeNotice = mutation({
   args: acknowledgeNoticeArgs,
   returns: acknowledgeNoticeReturns,
   handler: acknowledgeNoticeHandler,
+});
+
+// Mobile-specific functions for tenant users
+export const mobileGetNotices = query({
+  args: mobileGetNoticesArgs,
+  returns: mobileGetNoticesReturns,
+  handler: mobileGetNoticesHandler,
+});
+
+export const mobileGetNoticeById = query({
+  args: mobileGetNoticeByIdArgs,
+  returns: mobileGetNoticeByIdReturns,
+  handler: mobileGetNoticeByIdHandler,
+});
+
+export const mobileAcknowledgeNotice = mutation({
+  args: mobileAcknowledgeNoticeArgs,
+  returns: mobileAcknowledgeNoticeReturns,
+  handler: mobileAcknowledgeNoticeHandler,
+});
+
+export const mobileGetEvents = query({
+  args: mobileGetEventsArgs,
+  returns: mobileGetEventsReturns,
+  handler: mobileGetEventsHandler,
+});
+
+export const mobileAddEventToCalendar = mutation({
+  args: mobileAddEventToCalendarArgs,
+  returns: mobileAddEventToCalendarReturns,
+  handler: mobileAddEventToCalendarHandler,
+});
+
+export const mobileGetActivePolls = query({
+  args: mobileGetActivePollsArgs,
+  returns: mobileGetActivePollsReturns,
+  handler: mobileGetActivePollsHandler,
+});
+
+export const mobileSubmitPollResponse = mutation({
+  args: mobileSubmitPollResponseArgs,
+  returns: mobileSubmitPollResponseReturns,
+  handler: mobileSubmitPollResponseHandler,
+});
+
+export const mobileSendFeedback = mutation({
+  args: mobileSendFeedbackArgs,
+  returns: mobileSendFeedbackReturns,
+  handler: mobileSendFeedbackHandler,
+});
+
+export const mobileGetCommunityNews = query({
+  args: mobileGetCommunityNewsArgs,
+  returns: mobileGetCommunityNewsReturns,
+  handler: mobileGetCommunityNewsHandler,
 });

--- a/convex/noticeboardDefinitions/index.ts
+++ b/convex/noticeboardDefinitions/index.ts
@@ -1,4 +1,4 @@
-// Queries
+// Web Queries
 export * from './web/queries/getNotices';
 export * from './web/queries/getNoticeById';
 export * from './web/queries/getNoticeAcknowledgments';
@@ -6,7 +6,7 @@ export * from './web/queries/getManagerProperties';
 export * from './web/queries/getUnitsByProperty';
 export * from './web/queries/getAllUnits';
 
-// Mutations
+// Web Mutations
 export * from './web/mutations/createNotice';
 export * from './web/mutations/updateNotice';
 export * from './web/mutations/deleteNotice';
@@ -14,3 +14,52 @@ export * from './web/mutations/sendNoticeToAll';
 export * from './web/mutations/sendNoticeToUnit';
 export * from './web/mutations/scheduleNotice';
 export * from './web/mutations/acknowledgeNotice';
+
+// Mobile Queries
+export {
+  mobileGetNoticesArgs as getNoticesArgs,
+  mobileGetNoticesHandler as getNoticesHandler,
+  mobileGetNoticesReturns as getNoticesReturns,
+} from './mobile/queries/getNotices';
+export {
+  mobileGetNoticeByIdArgs as getNoticeByIdArgs,
+  mobileGetNoticeByIdHandler as getNoticeByIdHandler,
+  mobileGetNoticeByIdReturns as getNoticeByIdReturns,
+} from './mobile/queries/getNoticeById';
+export {
+  mobileGetEventsArgs as getEventsArgs,
+  mobileGetEventsHandler as getEventsHandler,
+  mobileGetEventsReturns as getEventsReturns,
+} from './mobile/queries/getEvents';
+export {
+  mobileGetActivePollsArgs as getActivePollsArgs,
+  mobileGetActivePollsHandler as getActivePollsHandler,
+  mobileGetActivePollsReturns as getActivePollsReturns,
+} from './mobile/queries/getActivePolls';
+export {
+  mobileGetCommunityNewsArgs as getCommunityNewsArgs,
+  mobileGetCommunityNewsHandler as getCommunityNewsHandler,
+  mobileGetCommunityNewsReturns as getCommunityNewsReturns,
+} from './mobile/queries/getCommunityNews';
+
+// Mobile Mutations
+export {
+  mobileAcknowledgeNoticeArgs as acknowledgeNoticeArgs,
+  mobileAcknowledgeNoticeHandler as acknowledgeNoticeHandler,
+  mobileAcknowledgeNoticeReturns as acknowledgeNoticeReturns,
+} from './mobile/mutations/acknowledgeNotice';
+export {
+  mobileAddEventToCalendarArgs as addEventToCalendarArgs,
+  mobileAddEventToCalendarHandler as addEventToCalendarHandler,
+  mobileAddEventToCalendarReturns as addEventToCalendarReturns,
+} from './mobile/mutations/addEventToCalendar';
+export {
+  mobileSubmitPollResponseArgs as submitPollResponseArgs,
+  mobileSubmitPollResponseHandler as submitPollResponseHandler,
+  mobileSubmitPollResponseReturns as submitPollResponseReturns,
+} from './mobile/mutations/submitPollResponse';
+export {
+  mobileSendFeedbackArgs as sendFeedbackArgs,
+  mobileSendFeedbackHandler as sendFeedbackHandler,
+  mobileSendFeedbackReturns as sendFeedbackReturns,
+} from './mobile/mutations/sendFeedback';

--- a/convex/noticeboardDefinitions/mobile/mutations/acknowledgeNotice.ts
+++ b/convex/noticeboardDefinitions/mobile/mutations/acknowledgeNotice.ts
@@ -1,0 +1,93 @@
+import { v } from 'convex/values';
+import { MutationCtx } from '../../../_generated/server';
+import { Id } from '../../../_generated/dataModel';
+
+export const mobileAcknowledgeNoticeArgs = {
+  noticeId: v.id('notices'),
+} as const;
+
+export const mobileAcknowledgeNoticeReturns = v.union(
+  v.object({
+    _id: v.id('noticeAcknowledgments'),
+    _creationTime: v.number(),
+    noticeId: v.id('notices'),
+    userId: v.id('users'),
+    acknowledgedAt: v.number(),
+  }),
+  v.null()
+);
+
+type Args = {
+  noticeId: Id<'notices'>;
+};
+
+export const mobileAcknowledgeNoticeHandler = async (ctx: MutationCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Verify the notice exists and user has access
+  const notice = await ctx.db.get(args.noticeId);
+  if (!notice || !notice.isActive) return null;
+
+  // Check if user has access to this notice (same property/units)
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  const hasAccess = userProperties.some(up => up.propertyId === notice.propertyId);
+  if (!hasAccess) throw new Error('Access denied: Notice not available for this user');
+
+  // Check if this notice is targeted at the user
+  let canAccess = false;
+  if (notice.targetAudience === 'all') {
+    canAccess = true;
+  } else if (notice.targetAudience === 'tenants') {
+    canAccess = true;
+  } else if (notice.targetAudience === 'specific_units') {
+    if (notice.targetUnits && notice.targetUnits.length > 0) {
+      // Check if user is tenant of any of the target units
+      const userUnits = await ctx.db
+        .query('units')
+        .filter(q => q.and(q.eq(q.field('tenantId'), currentUser._id), q.eq(q.field('isOccupied'), true)))
+        .collect();
+      const userUnitIds = userUnits.map(unit => unit._id);
+      canAccess = notice.targetUnits.some(unitId => userUnitIds.includes(unitId));
+    }
+  }
+
+  if (!canAccess) throw new Error('Access denied: Notice not targeted at this user');
+
+  // Check if user has already acknowledged this notice
+  const existingAck = await ctx.db
+    .query('noticeAcknowledgments')
+    .withIndex('by_notice_user', q => q.eq('noticeId', args.noticeId).eq('userId', currentUser._id))
+    .unique();
+
+  if (existingAck) {
+    // Return existing acknowledgment
+    return existingAck;
+  }
+
+  // Create new acknowledgment
+  const acknowledgmentId = await ctx.db.insert('noticeAcknowledgments', {
+    noticeId: args.noticeId,
+    userId: currentUser._id,
+    acknowledgedAt: Date.now(),
+  });
+
+  // Return the created acknowledgment
+  const createdAck = await ctx.db.get(acknowledgmentId);
+  if (!createdAck) throw new Error('Failed to create acknowledgment');
+
+  return createdAck;
+};

--- a/convex/noticeboardDefinitions/mobile/mutations/addEventToCalendar.ts
+++ b/convex/noticeboardDefinitions/mobile/mutations/addEventToCalendar.ts
@@ -1,0 +1,102 @@
+import { v } from 'convex/values';
+import { MutationCtx } from '../../../_generated/server';
+import { Id } from '../../../_generated/dataModel';
+
+export const mobileAddEventToCalendarArgs = {
+  eventId: v.id('events'),
+  status: v.union(v.literal('attending'), v.literal('maybe'), v.literal('declined')),
+} as const;
+
+export const mobileAddEventToCalendarReturns = v.union(
+  v.object({
+    _id: v.id('eventAttendees'),
+    _creationTime: v.number(),
+    eventId: v.id('events'),
+    userId: v.id('users'),
+    status: v.string(),
+    registeredAt: v.number(),
+  }),
+  v.null()
+);
+
+type Args = {
+  eventId: Id<'events'>;
+  status: 'attending' | 'maybe' | 'declined';
+};
+
+export const mobileAddEventToCalendarHandler = async (ctx: MutationCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Verify the event exists and user has access
+  const event = await ctx.db.get(args.eventId);
+  if (!event) return null;
+
+  // Check if user has access to this event (same property)
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  const hasAccess = userProperties.some(up => up.propertyId === event.propertyId);
+  if (!hasAccess) throw new Error('Access denied: Event not available for this user');
+
+  // Check if event is in the past
+  if (event.endDate < Date.now()) {
+    throw new Error('Cannot RSVP to past events');
+  }
+
+  // Check if event has capacity and is full (only for attending status)
+  if (args.status === 'attending' && event.maxAttendees) {
+    const currentAttendees = await ctx.db
+      .query('eventAttendees')
+      .withIndex('by_event', q => q.eq('eventId', args.eventId))
+      .filter(q => q.eq(q.field('status'), 'attending'))
+      .collect();
+
+    if (currentAttendees.length >= event.maxAttendees) {
+      throw new Error('Event is at full capacity');
+    }
+  }
+
+  // Check if user has already RSVP'd to this event
+  const existingRSVP = await ctx.db
+    .query('eventAttendees')
+    .withIndex('by_event_user', q => q.eq('eventId', args.eventId).eq('userId', currentUser._id))
+    .unique();
+
+  if (existingRSVP) {
+    // Update existing RSVP
+    await ctx.db.patch(existingRSVP._id, {
+      status: args.status,
+      registeredAt: Date.now(),
+    });
+
+    // Return updated RSVP
+    const updatedRSVP = await ctx.db.get(existingRSVP._id);
+    return updatedRSVP || null;
+  } else {
+    // Create new RSVP
+    const rsvpId = await ctx.db.insert('eventAttendees', {
+      eventId: args.eventId,
+      userId: currentUser._id,
+      status: args.status,
+      registeredAt: Date.now(),
+    });
+
+    // Return the created RSVP
+    const createdRSVP = await ctx.db.get(rsvpId);
+    if (!createdRSVP) throw new Error('Failed to create RSVP');
+
+    return createdRSVP;
+  }
+};

--- a/convex/noticeboardDefinitions/mobile/mutations/sendFeedback.ts
+++ b/convex/noticeboardDefinitions/mobile/mutations/sendFeedback.ts
@@ -1,0 +1,110 @@
+import { v } from 'convex/values';
+import { MutationCtx } from '../../../_generated/server';
+import { Id } from '../../../_generated/dataModel';
+
+export const mobileSendFeedbackArgs = {
+  propertyId: v.id('properties'),
+  subject: v.string(),
+  message: v.string(),
+  feedbackType: v.union(
+    v.literal('general'),
+    v.literal('maintenance'),
+    v.literal('service'),
+    v.literal('complaint'),
+    v.literal('suggestion'),
+    v.literal('praise')
+  ),
+  priority: v.optional(v.union(v.literal('low'), v.literal('medium'), v.literal('high'), v.literal('urgent'))),
+  attachments: v.optional(v.array(v.string())), // File URLs
+} as const;
+
+export const mobileSendFeedbackReturns = v.object({
+  _id: v.id('notices'),
+  _creationTime: v.number(),
+  propertyId: v.id('properties'),
+  createdBy: v.id('users'),
+  title: v.string(),
+  content: v.string(),
+  noticeType: v.string(),
+  priority: v.string(),
+  targetAudience: v.string(),
+  isActive: v.boolean(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});
+
+type Args = {
+  propertyId: Id<'properties'>;
+  subject: string;
+  message: string;
+  feedbackType: 'general' | 'maintenance' | 'service' | 'complaint' | 'suggestion' | 'praise';
+  priority?: 'low' | 'medium' | 'high' | 'urgent';
+  attachments?: string[];
+};
+
+export const mobileSendFeedbackHandler = async (ctx: MutationCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Verify user has access to this property
+  const userProperty = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user_property', q => q.eq('userId', currentUser._id).eq('propertyId', args.propertyId))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .unique();
+
+  if (!userProperty) {
+    throw new Error('Access denied: You do not have access to this property');
+  }
+
+  // Get property info for validation
+  const property = await ctx.db.get(args.propertyId);
+  if (!property) throw new Error('Property not found');
+
+  // Create feedback as a notice with special type
+  const feedbackNoticeId = await ctx.db.insert('notices', {
+    propertyId: args.propertyId,
+    createdBy: currentUser._id,
+    title: `[Feedback - ${args.feedbackType.toUpperCase()}] ${args.subject}`,
+    content: args.message,
+    noticeType: 'feedback', // Special notice type for feedback
+    priority: args.priority || 'medium',
+    targetAudience: 'managers', // Feedback goes to property managers
+    targetUnits: undefined,
+    isActive: true,
+    scheduledAt: undefined,
+    expiresAt: undefined,
+    attachments: args.attachments,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  // Get the created feedback notice
+  const createdFeedback = await ctx.db.get(feedbackNoticeId);
+  if (!createdFeedback) throw new Error('Failed to create feedback');
+
+  // Create an audit log entry for the feedback submission
+  await ctx.db.insert('auditLogs', {
+    propertyId: args.propertyId,
+    userId: currentUser._id,
+    action: 'submit_feedback',
+    resourceType: 'notices',
+    resourceId: feedbackNoticeId,
+    newValues: {
+      feedbackType: args.feedbackType,
+      subject: args.subject,
+      priority: args.priority,
+    },
+    timestamp: Date.now(),
+  });
+
+  return createdFeedback;
+};

--- a/convex/noticeboardDefinitions/mobile/mutations/submitPollResponse.ts
+++ b/convex/noticeboardDefinitions/mobile/mutations/submitPollResponse.ts
@@ -1,0 +1,128 @@
+import { v } from 'convex/values';
+import { MutationCtx } from '../../../_generated/server';
+import { Id } from '../../../_generated/dataModel';
+
+export const mobileSubmitPollResponseArgs = {
+  pollId: v.id('polls'),
+  selectedOptions: v.array(v.number()), // Array of indices for selected options
+  textResponse: v.optional(v.string()), // For text-based polls
+} as const;
+
+export const mobileSubmitPollResponseReturns = v.union(
+  v.object({
+    _id: v.id('pollResponses'),
+    _creationTime: v.number(),
+    pollId: v.id('polls'),
+    userId: v.optional(v.id('users')),
+    selectedOptions: v.array(v.number()),
+    textResponse: v.optional(v.string()),
+    submittedAt: v.number(),
+  }),
+  v.null()
+);
+
+type Args = {
+  pollId: Id<'polls'>;
+  selectedOptions: number[];
+  textResponse?: string;
+};
+
+export const mobileSubmitPollResponseHandler = async (ctx: MutationCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Verify the poll exists and is active
+  const poll = await ctx.db.get(args.pollId);
+  if (!poll || !poll.isActive) return null;
+
+  // Check if poll has expired
+  if (poll.expiresAt && poll.expiresAt < Date.now()) {
+    throw new Error('Poll has expired');
+  }
+
+  // Check if user has access to this poll (same property)
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  const hasAccess = userProperties.some(up => up.propertyId === poll.propertyId);
+  if (!hasAccess) throw new Error('Access denied: Poll not available for this user');
+
+  // Validate selected options
+  if (args.selectedOptions.length === 0 && !args.textResponse) {
+    throw new Error('Must provide either selected options or text response');
+  }
+
+  // Validate option indices are within bounds
+  if (args.selectedOptions.length > 0) {
+    const maxOptionIndex = poll.options.length - 1;
+    const invalidOptions = args.selectedOptions.filter(index => index < 0 || index > maxOptionIndex);
+    if (invalidOptions.length > 0) {
+      throw new Error(`Invalid option indices: ${invalidOptions.join(', ')}`);
+    }
+
+    // For single choice polls, ensure only one option is selected
+    if (poll.pollType === 'single_choice' && args.selectedOptions.length > 1) {
+      throw new Error('Single choice polls can only have one selected option');
+    }
+
+    // For multiple choice polls, ensure at least one option is selected
+    if (poll.pollType === 'multiple_choice' && args.selectedOptions.length === 0) {
+      throw new Error('Multiple choice polls must have at least one selected option');
+    }
+  }
+
+  // For rating polls, ensure exactly one option is selected
+  if (poll.pollType === 'rating' && args.selectedOptions.length !== 1) {
+    throw new Error('Rating polls must have exactly one selected option');
+  }
+
+  // For text polls, ensure text response is provided
+  if (poll.pollType === 'text' && !args.textResponse) {
+    throw new Error('Text polls must have a text response');
+  }
+
+  // Check if user has already responded to this poll
+  const existingResponse = await ctx.db
+    .query('pollResponses')
+    .withIndex('by_poll_user', q => q.eq('pollId', args.pollId).eq('userId', currentUser._id))
+    .unique();
+
+  if (existingResponse) {
+    // Update existing response
+    await ctx.db.patch(existingResponse._id, {
+      selectedOptions: args.selectedOptions,
+      textResponse: args.textResponse,
+      submittedAt: Date.now(),
+    });
+
+    // Return updated response
+    const updatedResponse = await ctx.db.get(existingResponse._id);
+    return updatedResponse || null;
+  } else {
+    // Create new response
+    const responseId = await ctx.db.insert('pollResponses', {
+      pollId: args.pollId,
+      userId: poll.allowAnonymous ? undefined : currentUser._id,
+      selectedOptions: args.selectedOptions,
+      textResponse: args.textResponse,
+      submittedAt: Date.now(),
+    });
+
+    // Return the created response
+    const createdResponse = await ctx.db.get(responseId);
+    if (!createdResponse) throw new Error('Failed to create poll response');
+
+    return createdResponse;
+  }
+};

--- a/convex/noticeboardDefinitions/mobile/queries/getActivePolls.ts
+++ b/convex/noticeboardDefinitions/mobile/queries/getActivePolls.ts
@@ -1,0 +1,196 @@
+import { v } from 'convex/values';
+import { PaginationOptions, paginationOptsValidator } from 'convex/server';
+import { QueryCtx } from '../../../_generated/server';
+import { Doc } from '../../../_generated/dataModel';
+
+export const mobileGetActivePollsArgs = {
+  paginationOpts: paginationOptsValidator,
+  search: v.optional(v.string()),
+} as const;
+
+export const mobileGetActivePollsReturns = v.object({
+  page: v.array(
+    v.object({
+      _id: v.id('polls'),
+      _creationTime: v.number(),
+      propertyId: v.id('properties'),
+      createdBy: v.id('users'),
+      title: v.string(),
+      description: v.string(),
+      question: v.string(),
+      options: v.array(v.string()),
+      pollType: v.string(),
+      isActive: v.boolean(),
+      allowAnonymous: v.boolean(),
+      expiresAt: v.optional(v.number()),
+      createdAt: v.number(),
+      updatedAt: v.number(),
+      // Mobile-specific fields
+      hasResponded: v.boolean(),
+      responseCount: v.number(),
+      isExpired: v.boolean(),
+      timeRemaining: v.optional(v.number()), // milliseconds until expiry
+      // Joined data
+      property: v.object({
+        _id: v.id('properties'),
+        name: v.string(),
+        address: v.string(),
+      }),
+      creator: v.object({
+        _id: v.id('users'),
+        firstName: v.string(),
+        lastName: v.string(),
+      }),
+    })
+  ),
+  isDone: v.boolean(),
+  continueCursor: v.optional(v.string()),
+});
+
+type Args = {
+  paginationOpts: PaginationOptions;
+  search?: string;
+};
+
+export const mobileGetActivePollsHandler = async (ctx: QueryCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Get user's properties
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  if (userProperties.length === 0) {
+    return {
+      page: [],
+      isDone: true,
+      continueCursor: undefined,
+    };
+  }
+
+  const propertyIds = userProperties.map(up => up.propertyId);
+
+  // Capture current timestamp; do NOT use it inside the Convex query to keep cursor identity stable
+  const now = Date.now();
+
+  // Helper function to build the base query
+  const buildBaseQuery = () => {
+    let query = ctx.db.query('polls');
+
+    // Filter by user's properties - use a safer approach
+    if (propertyIds.length > 0) {
+      query = query.filter(q => {
+        const conditions = propertyIds.map(propertyId => q.eq(q.field('propertyId'), propertyId));
+        return q.or(...conditions);
+      });
+    }
+
+    // Only show active polls
+    query = query.filter(q => q.eq(q.field('isActive'), true));
+
+    return query;
+  };
+
+  // Order by creation time (newest first) and paginate
+  let results;
+  try {
+    const baseQuery = buildBaseQuery();
+    results = await baseQuery.order('desc').paginate(args.paginationOpts);
+  } catch (error) {
+    // If cursor is invalid (from a different query/session), start from beginning
+    const message = (error as Error)?.message ?? '';
+    if (message.includes('InvalidCursor')) {
+      console.warn('Invalid cursor detected during hot reload, starting from beginning');
+      const freshQuery = buildBaseQuery();
+      results = await freshQuery.order('desc').paginate({
+        numItems: args.paginationOpts.numItems,
+        cursor: null,
+      });
+    } else {
+      throw error;
+    }
+  }
+
+  // Enrich with related data and response status
+  const enrichedPage = await Promise.all(
+    results.page.map(async (poll: Doc<'polls'>) => {
+      // Get property info
+      const property = await ctx.db.get(poll.propertyId);
+      if (!property) throw new Error('Property not found');
+
+      // Get creator info
+      const creator = await ctx.db.get(poll.createdBy);
+      if (!creator) throw new Error('Creator not found');
+
+      // Check if user has responded to this poll
+      const userResponse = await ctx.db
+        .query('pollResponses')
+        .withIndex('by_poll_user', q => q.eq('pollId', poll._id).eq('userId', currentUser._id))
+        .unique();
+
+      const hasResponded = !!userResponse;
+
+      // Get response count
+      const allResponses = await ctx.db
+        .query('pollResponses')
+        .withIndex('by_poll', q => q.eq('pollId', poll._id))
+        .collect();
+      const responseCount = allResponses.length;
+
+      // Check if poll is expired
+      const isExpired = poll.expiresAt ? poll.expiresAt < now : false;
+
+      // Calculate time remaining
+      const timeRemaining = poll.expiresAt && !isExpired ? poll.expiresAt - now : undefined;
+
+      return {
+        ...poll,
+        hasResponded,
+        responseCount,
+        isExpired,
+        timeRemaining,
+        property: {
+          _id: property._id,
+          name: property.name,
+          address: property.address,
+        },
+        creator: {
+          _id: creator._id,
+          firstName: creator.firstName,
+          lastName: creator.lastName,
+        },
+      };
+    })
+  );
+
+  // Apply post-query filters after enrichment to avoid cursor identity changes
+  // 1) Filter out expired polls
+  let filteredPage = enrichedPage.filter(poll => !poll.isExpired);
+  // 2) Apply search filter if provided
+  if (args.search) {
+    const searchTerm = args.search.toLowerCase();
+    filteredPage = enrichedPage.filter(
+      poll =>
+        poll.title.toLowerCase().includes(searchTerm) ||
+        poll.description.toLowerCase().includes(searchTerm) ||
+        poll.question.toLowerCase().includes(searchTerm)
+    );
+  }
+
+  return {
+    page: filteredPage,
+    isDone: results.isDone,
+    continueCursor: results.continueCursor,
+  };
+};

--- a/convex/noticeboardDefinitions/mobile/queries/getCommunityNews.ts
+++ b/convex/noticeboardDefinitions/mobile/queries/getCommunityNews.ts
@@ -1,0 +1,194 @@
+import { v, ConvexError } from 'convex/values';
+import { PaginationOptions, paginationOptsValidator } from 'convex/server';
+import { QueryCtx } from '../../../_generated/server';
+import { Id, Doc } from '../../../_generated/dataModel';
+
+export const mobileGetCommunityNewsArgs = {
+  paginationOpts: paginationOptsValidator,
+  search: v.optional(v.string()),
+} as const;
+
+export const mobileGetCommunityNewsReturns = v.object({
+  page: v.array(
+    v.object({
+      _id: v.id('notices'),
+      _creationTime: v.number(),
+      propertyId: v.id('properties'),
+      unitId: v.optional(v.id('units')),
+      createdBy: v.id('users'),
+      title: v.string(),
+      content: v.string(),
+      noticeType: v.string(),
+      priority: v.string(),
+      targetAudience: v.string(),
+      isActive: v.boolean(),
+      scheduledAt: v.optional(v.number()),
+      expiresAt: v.optional(v.number()),
+      attachments: v.optional(v.array(v.string())),
+      createdAt: v.number(),
+      updatedAt: v.number(),
+      // Mobile-specific fields
+      isRead: v.boolean(),
+      // Joined data
+      property: v.object({
+        _id: v.id('properties'),
+        name: v.string(),
+        address: v.string(),
+      }),
+      creator: v.object({
+        _id: v.id('users'),
+        firstName: v.string(),
+        lastName: v.string(),
+      }),
+      unit: v.optional(
+        v.object({
+          _id: v.id('units'),
+          unitNumber: v.string(),
+        })
+      ),
+    })
+  ),
+  isDone: v.boolean(),
+  continueCursor: v.optional(v.string()),
+});
+
+type Args = {
+  paginationOpts: PaginationOptions;
+  search?: string;
+};
+
+export const mobileGetCommunityNewsHandler = async (ctx: QueryCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Get user's properties
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  if (userProperties.length === 0) {
+    return {
+      page: [],
+      isDone: true,
+      continueCursor: undefined,
+    };
+  }
+
+  const propertyIds = userProperties.map(up => up.propertyId);
+
+  // Build query for community news relevant to this user
+  // Community news includes: announcements, community events, general notices, emergency notices
+  let baseQuery = ctx.db.query('notices');
+
+  // Filter by user's properties
+  baseQuery = baseQuery.filter(q => q.or(...propertyIds.map(propertyId => q.eq(q.field('propertyId'), propertyId))));
+
+  // Filter for community-focused notice types
+  baseQuery = baseQuery.filter(q =>
+    q.or(
+      q.eq(q.field('noticeType'), 'announcement'),
+      q.eq(q.field('noticeType'), 'event'),
+      q.eq(q.field('noticeType'), 'general'),
+      q.eq(q.field('noticeType'), 'emergency')
+    )
+  );
+
+  // Only show active notices
+  baseQuery = baseQuery.filter(q => q.eq(q.field('isActive'), true));
+
+  // Filter by community-relevant target audiences
+  baseQuery = baseQuery.filter(q =>
+    q.or(q.eq(q.field('targetAudience'), 'all'), q.eq(q.field('targetAudience'), 'tenants'))
+  );
+
+  // Order by priority (urgent/high first) then by creation time (newest first)
+  let results;
+  try {
+    results = await baseQuery.order('desc').paginate(args.paginationOpts);
+  } catch (error) {
+    // If cursor is invalid (from a different query/session), start from beginning
+    if (error instanceof ConvexError && error.data?.code === 'InvalidCursor') {
+      console.warn('Invalid cursor detected during hot reload, starting from beginning');
+      results = await baseQuery.order('desc').paginate({
+        numItems: args.paginationOpts.numItems,
+        cursor: null,
+      });
+    } else {
+      throw error;
+    }
+  }
+
+  // Enrich with related data and read status
+  const enrichedPage = await Promise.all(
+    results.page.map(async (notice: Doc<'notices'>) => {
+      // Get property info
+      const property = await ctx.db.get(notice.propertyId);
+      if (!property) throw new Error('Property not found');
+
+      // Get creator info
+      const creator = await ctx.db.get(notice.createdBy);
+      if (!creator) throw new Error('Creator not found');
+
+      // Get unit info if applicable
+      let unit = undefined;
+      if (notice.unitId) {
+        const unitData = await ctx.db.get(notice.unitId);
+        if (unitData) {
+          unit = {
+            _id: unitData._id,
+            unitNumber: unitData.unitNumber,
+          };
+        }
+      }
+
+      // Check if user has acknowledged this notice
+      const acknowledgment = await ctx.db
+        .query('noticeAcknowledgments')
+        .withIndex('by_notice_user', q => q.eq('noticeId', notice._id).eq('userId', currentUser._id))
+        .unique();
+
+      const isRead = !!acknowledgment;
+
+      return {
+        ...notice,
+        isRead,
+        property: {
+          _id: property._id,
+          name: property.name,
+          address: property.address,
+        },
+        creator: {
+          _id: creator._id,
+          firstName: creator.firstName,
+          lastName: creator.lastName,
+        },
+        unit,
+      };
+    })
+  );
+
+  // Apply search filter if provided
+  let filteredPage = enrichedPage;
+  if (args.search) {
+    const searchTerm = args.search.toLowerCase();
+    filteredPage = enrichedPage.filter(
+      notice => notice.title.toLowerCase().includes(searchTerm) || notice.content.toLowerCase().includes(searchTerm)
+    );
+  }
+
+  return {
+    page: filteredPage,
+    isDone: results.isDone,
+    continueCursor: results.continueCursor,
+  };
+};

--- a/convex/noticeboardDefinitions/mobile/queries/getEvents.ts
+++ b/convex/noticeboardDefinitions/mobile/queries/getEvents.ts
@@ -1,0 +1,200 @@
+import { v, ConvexError } from 'convex/values';
+import { PaginationOptions, paginationOptsValidator } from 'convex/server';
+import { QueryCtx } from '../../../_generated/server';
+import { Doc } from '../../../_generated/dataModel';
+
+export const mobileGetEventsArgs = {
+  paginationOpts: paginationOptsValidator,
+  eventType: v.optional(
+    v.union(
+      v.literal('community'),
+      v.literal('maintenance'),
+      v.literal('meeting'),
+      v.literal('social'),
+      v.literal('emergency')
+    )
+  ),
+  startDate: v.optional(v.number()),
+  endDate: v.optional(v.number()),
+  isPublic: v.optional(v.boolean()),
+  search: v.optional(v.string()),
+} as const;
+
+export const mobileGetEventsReturns = v.object({
+  page: v.array(
+    v.object({
+      _id: v.id('events'),
+      _creationTime: v.number(),
+      propertyId: v.id('properties'),
+      createdBy: v.id('users'),
+      title: v.string(),
+      description: v.string(),
+      eventType: v.string(),
+      startDate: v.number(),
+      endDate: v.number(),
+      location: v.optional(v.string()),
+      isRecurring: v.boolean(),
+      recurringPattern: v.optional(v.string()),
+      maxAttendees: v.optional(v.number()),
+      isPublic: v.boolean(),
+      createdAt: v.number(),
+      updatedAt: v.number(),
+      // Mobile-specific fields
+      isAttending: v.union(v.literal('attending'), v.literal('maybe'), v.literal('declined'), v.null()),
+      attendeeCount: v.number(),
+      isFull: v.boolean(),
+      // Joined data
+      property: v.object({
+        _id: v.id('properties'),
+        name: v.string(),
+        address: v.string(),
+      }),
+      creator: v.object({
+        _id: v.id('users'),
+        firstName: v.string(),
+        lastName: v.string(),
+      }),
+    })
+  ),
+  isDone: v.boolean(),
+  continueCursor: v.optional(v.string()),
+});
+
+type Args = {
+  paginationOpts: PaginationOptions;
+  eventType?: 'community' | 'maintenance' | 'meeting' | 'social' | 'emergency';
+  startDate?: number;
+  endDate?: number;
+  isPublic?: boolean;
+  search?: string;
+};
+
+export const mobileGetEventsHandler = async (ctx: QueryCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Get user's properties
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  if (userProperties.length === 0) {
+    return {
+      page: [],
+      isDone: true,
+      continueCursor: undefined,
+    };
+  }
+
+  const propertyIds = userProperties.map(up => up.propertyId);
+
+  // Build query for events relevant to this user
+  let baseQuery = ctx.db.query('events');
+
+  // Filter by user's properties
+  baseQuery = baseQuery.filter(q => q.or(...propertyIds.map(propertyId => q.eq(q.field('propertyId'), propertyId))));
+
+  // Apply additional filters
+  if (args.eventType) {
+    baseQuery = baseQuery.filter(q => q.eq(q.field('eventType'), args.eventType!));
+  }
+  if (args.isPublic !== undefined) {
+    baseQuery = baseQuery.filter(q => q.eq(q.field('isPublic'), args.isPublic!));
+  }
+  if (args.startDate) {
+    baseQuery = baseQuery.filter(q => q.gte(q.field('startDate'), args.startDate!));
+  }
+  if (args.endDate) {
+    baseQuery = baseQuery.filter(q => q.lte(q.field('endDate'), args.endDate!));
+  }
+
+  // Order by start date (upcoming first)
+  let results;
+  try {
+    results = await baseQuery.order('asc').paginate(args.paginationOpts);
+  } catch (error) {
+    // If cursor is invalid (from a different query/session), start from beginning
+    if (error instanceof ConvexError && error.data?.code === 'InvalidCursor') {
+      console.warn('Invalid cursor detected during hot reload, starting from beginning');
+      results = await baseQuery.order('asc').paginate({
+        numItems: args.paginationOpts.numItems,
+        cursor: null,
+      });
+    } else {
+      throw error;
+    }
+  }
+
+  // Enrich with related data and attendance status
+  const enrichedPage = await Promise.all(
+    results.page.map(async (event: Doc<'events'>) => {
+      // Get property info
+      const property = await ctx.db.get(event.propertyId);
+      if (!property) throw new Error('Property not found');
+
+      // Get creator info
+      const creator = await ctx.db.get(event.createdBy);
+      if (!creator) throw new Error('Creator not found');
+
+      // Check if user is attending this event
+      const userAttendance = await ctx.db
+        .query('eventAttendees')
+        .withIndex('by_event_user', q => q.eq('eventId', event._id).eq('userId', currentUser._id))
+        .unique();
+
+      const isAttending = userAttendance?.status || null;
+
+      // Get attendee count
+      const allAttendees = await ctx.db
+        .query('eventAttendees')
+        .withIndex('by_event', q => q.eq('eventId', event._id))
+        .collect();
+      const attendeeCount = allAttendees.length;
+
+      // Check if event is full
+      const isFull = event.maxAttendees ? attendeeCount >= event.maxAttendees : false;
+
+      return {
+        ...event,
+        isAttending,
+        attendeeCount,
+        isFull,
+        property: {
+          _id: property._id,
+          name: property.name,
+          address: property.address,
+        },
+        creator: {
+          _id: creator._id,
+          firstName: creator.firstName,
+          lastName: creator.lastName,
+        },
+      };
+    })
+  );
+
+  // Apply search filter if provided
+  let filteredPage = enrichedPage;
+  if (args.search) {
+    const searchTerm = args.search.toLowerCase();
+    filteredPage = enrichedPage.filter(
+      event => event.title.toLowerCase().includes(searchTerm) || event.description.toLowerCase().includes(searchTerm)
+    );
+  }
+
+  return {
+    page: filteredPage,
+    isDone: results.isDone,
+    continueCursor: results.continueCursor,
+  };
+};

--- a/convex/noticeboardDefinitions/mobile/queries/getNoticeById.ts
+++ b/convex/noticeboardDefinitions/mobile/queries/getNoticeById.ts
@@ -1,0 +1,184 @@
+import { v } from 'convex/values';
+import { QueryCtx } from '../../../_generated/server';
+import { Id } from '../../../_generated/dataModel';
+
+export const mobileGetNoticeByIdArgs = {
+  noticeId: v.id('notices'),
+} as const;
+
+export const mobileGetNoticeByIdReturns = v.union(
+  v.object({
+    _id: v.id('notices'),
+    _creationTime: v.number(),
+    propertyId: v.id('properties'),
+    unitId: v.optional(v.id('units')),
+    createdBy: v.id('users'),
+    title: v.string(),
+    content: v.string(),
+    noticeType: v.string(),
+    priority: v.string(),
+    targetAudience: v.string(),
+    targetUnits: v.optional(v.array(v.id('units'))),
+    isActive: v.boolean(),
+    scheduledAt: v.optional(v.number()),
+    expiresAt: v.optional(v.number()),
+    attachments: v.optional(v.array(v.string())),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    // Mobile-specific fields
+    isRead: v.boolean(),
+    acknowledgedAt: v.optional(v.number()),
+    canAcknowledge: v.boolean(),
+    // Joined data
+    property: v.object({
+      _id: v.id('properties'),
+      name: v.string(),
+      address: v.string(),
+    }),
+    creator: v.object({
+      _id: v.id('users'),
+      firstName: v.string(),
+      lastName: v.string(),
+    }),
+    unit: v.optional(
+      v.object({
+        _id: v.id('units'),
+        unitNumber: v.string(),
+      })
+    ),
+    acknowledgmentStats: v.object({
+      totalAcknowledged: v.number(),
+      totalTargetUsers: v.number(),
+    }),
+  }),
+  v.null()
+);
+
+type Args = {
+  noticeId: Id<'notices'>;
+};
+
+export const mobileGetNoticeByIdHandler = async (ctx: QueryCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Get the notice
+  const notice = await ctx.db.get(args.noticeId);
+  if (!notice) return null;
+
+  // Check if user has access to this notice (same property/units)
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  const hasAccess = userProperties.some(up => up.propertyId === notice.propertyId);
+  if (!hasAccess) return null; // User doesn't have access to this notice
+
+  // Check if this notice is targeted at the user
+  let canAccess = false;
+  if (notice.targetAudience === 'all') {
+    canAccess = true;
+  } else if (notice.targetAudience === 'tenants') {
+    canAccess = true;
+  } else if (notice.targetAudience === 'specific_units') {
+    if (notice.targetUnits && notice.targetUnits.length > 0) {
+      // Check if user is tenant of any of the target units
+      const userUnits = await ctx.db
+        .query('units')
+        .filter(q => q.and(q.eq(q.field('tenantId'), currentUser._id), q.eq(q.field('isOccupied'), true)))
+        .collect();
+      const userUnitIds = userUnits.map(unit => unit._id);
+      canAccess = notice.targetUnits.some(unitId => userUnitIds.includes(unitId));
+    }
+  }
+
+  if (!canAccess) return null;
+
+  // Get property info
+  const property = await ctx.db.get(notice.propertyId);
+  if (!property) throw new Error('Property not found');
+
+  // Get creator info
+  const creator = await ctx.db.get(notice.createdBy);
+  if (!creator) throw new Error('Creator not found');
+
+  // Get unit info if applicable
+  let unit = undefined;
+  if (notice.unitId) {
+    const unitData = await ctx.db.get(notice.unitId);
+    if (unitData) {
+      unit = {
+        _id: unitData._id,
+        unitNumber: unitData.unitNumber,
+      };
+    }
+  }
+
+  // Check if user has acknowledged this notice
+  const acknowledgment = await ctx.db
+    .query('noticeAcknowledgments')
+    .withIndex('by_notice_user', q => q.eq('noticeId', notice._id).eq('userId', currentUser._id))
+    .unique();
+
+  const isRead = !!acknowledgment;
+  const acknowledgedAt = acknowledgment?.acknowledgedAt;
+
+  // Calculate acknowledgment statistics
+  const allAcknowledgments = await ctx.db
+    .query('noticeAcknowledgments')
+    .withIndex('by_notice', q => q.eq('noticeId', notice._id))
+    .collect();
+  const totalAcknowledged = allAcknowledgments.length;
+
+  // Calculate total target users based on target audience
+  let totalTargetUsers = 0;
+  if (notice.targetAudience === 'all') {
+    const allUnits = await ctx.db
+      .query('units')
+      .withIndex('by_property', q => q.eq('propertyId', notice.propertyId))
+      .filter(q => q.eq(q.field('isOccupied'), true))
+      .collect();
+    totalTargetUsers = allUnits.length;
+  } else if (notice.targetAudience === 'tenants') {
+    const tenantUnits = await ctx.db
+      .query('units')
+      .withIndex('by_property', q => q.eq('propertyId', notice.propertyId))
+      .filter(q => q.eq(q.field('isOccupied'), true))
+      .collect();
+    totalTargetUsers = tenantUnits.length;
+  } else if (notice.targetAudience === 'specific_units' && notice.targetUnits) {
+    totalTargetUsers = notice.targetUnits.length;
+  }
+
+  return {
+    ...notice,
+    isRead,
+    acknowledgedAt,
+    canAcknowledge: !isRead && notice.isActive,
+    property: {
+      _id: property._id,
+      name: property.name,
+      address: property.address,
+    },
+    creator: {
+      _id: creator._id,
+      firstName: creator.firstName,
+      lastName: creator.lastName,
+    },
+    unit,
+    acknowledgmentStats: {
+      totalAcknowledged,
+      totalTargetUsers,
+    },
+  };
+};

--- a/convex/noticeboardDefinitions/mobile/queries/getNotices.ts
+++ b/convex/noticeboardDefinitions/mobile/queries/getNotices.ts
@@ -1,0 +1,228 @@
+import { v, ConvexError } from 'convex/values';
+import { PaginationOptions, paginationOptsValidator } from 'convex/server';
+import { QueryCtx } from '../../../_generated/server';
+import { Doc } from '../../../_generated/dataModel';
+
+export const mobileGetNoticesArgs = {
+  paginationOpts: paginationOptsValidator,
+  noticeType: v.optional(
+    v.union(
+      v.literal('announcement'),
+      v.literal('maintenance'),
+      v.literal('payment_reminder'),
+      v.literal('emergency'),
+      v.literal('event'),
+      v.literal('general')
+    )
+  ),
+  priority: v.optional(v.union(v.literal('low'), v.literal('medium'), v.literal('high'), v.literal('urgent'))),
+  isRead: v.optional(v.boolean()), // Filter by read/unread status
+  search: v.optional(v.string()),
+} as const;
+
+export const mobileGetNoticesReturns = v.object({
+  page: v.array(
+    v.object({
+      _id: v.id('notices'),
+      _creationTime: v.number(),
+      propertyId: v.id('properties'),
+      unitId: v.optional(v.id('units')),
+      createdBy: v.id('users'),
+      title: v.string(),
+      content: v.string(),
+      noticeType: v.string(),
+      priority: v.string(),
+      targetAudience: v.string(),
+      isActive: v.boolean(),
+      scheduledAt: v.optional(v.number()),
+      expiresAt: v.optional(v.number()),
+      attachments: v.optional(v.array(v.string())),
+      createdAt: v.number(),
+      updatedAt: v.number(),
+      // Mobile-specific fields
+      isRead: v.boolean(),
+      acknowledgedAt: v.optional(v.number()),
+      // Joined data
+      property: v.object({
+        _id: v.id('properties'),
+        name: v.string(),
+        address: v.string(),
+      }),
+      creator: v.object({
+        _id: v.id('users'),
+        firstName: v.string(),
+        lastName: v.string(),
+      }),
+      unit: v.optional(
+        v.object({
+          _id: v.id('units'),
+          unitNumber: v.string(),
+        })
+      ),
+    })
+  ),
+  isDone: v.boolean(),
+  continueCursor: v.optional(v.string()),
+});
+
+type Args = {
+  paginationOpts: PaginationOptions;
+  noticeType?: 'announcement' | 'maintenance' | 'payment_reminder' | 'emergency' | 'event' | 'general';
+  priority?: 'low' | 'medium' | 'high' | 'urgent';
+  isRead?: boolean;
+  search?: string;
+};
+
+export const mobileGetNoticesHandler = async (ctx: QueryCtx, args: Args) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error('Unauthorized');
+
+  // Get current tenant user
+  const currentUser = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', q => q.eq('clerkId', identity.subject))
+    .unique();
+  if (!currentUser) throw new Error('User not found');
+  if (currentUser.role !== 'tenant') throw new Error('Access denied: Tenants only');
+
+  // Get user's properties and units
+  const userProperties = await ctx.db
+    .query('userProperties')
+    .withIndex('by_user', q => q.eq('userId', currentUser._id))
+    .filter(q => q.eq(q.field('isActive'), true))
+    .collect();
+
+  if (userProperties.length === 0) {
+    return {
+      page: [],
+      isDone: true,
+      continueCursor: undefined,
+    };
+  }
+
+  const propertyIds = userProperties.map(up => up.propertyId);
+
+  // Get user's units for tenant-specific notices
+  const userUnits = await ctx.db
+    .query('units')
+    .filter(q => q.and(q.eq(q.field('tenantId'), currentUser._id), q.eq(q.field('isOccupied'), true)))
+    .collect();
+  const userUnitIds = userUnits.map(unit => unit._id);
+
+  // Build query for notices relevant to this user
+  let baseQuery = ctx.db.query('notices');
+
+  // Filter by user's properties
+  baseQuery = baseQuery.filter(q => q.or(...propertyIds.map(propertyId => q.eq(q.field('propertyId'), propertyId))));
+
+  // Apply additional filters
+  if (args.noticeType) {
+    baseQuery = baseQuery.filter(q => q.eq(q.field('noticeType'), args.noticeType!));
+  }
+  if (args.priority) {
+    baseQuery = baseQuery.filter(q => q.eq(q.field('priority'), args.priority!));
+  }
+
+  // Only show active notices
+  baseQuery = baseQuery.filter(q => q.eq(q.field('isActive'), true));
+
+  // Filter by target audience relevant to tenant
+  baseQuery = baseQuery.filter(q =>
+    q.or(
+      q.eq(q.field('targetAudience'), 'all'),
+      q.eq(q.field('targetAudience'), 'tenants'),
+      q.and(
+        q.eq(q.field('targetAudience'), 'specific_units'),
+        q.or(...userUnitIds.map(unitId => q.eq(q.field('unitId'), unitId)))
+      )
+    )
+  );
+
+  // Order by creation time (newest first) and priority
+  let results;
+  try {
+    results = await baseQuery.order('desc').paginate(args.paginationOpts);
+  } catch (error) {
+    // If cursor is invalid (from a different query/session), start from beginning
+    if (error instanceof ConvexError && error.data?.code === 'InvalidCursor') {
+      console.warn('Invalid cursor detected during hot reload, starting from beginning');
+      results = await baseQuery.order('desc').paginate({
+        numItems: args.paginationOpts.numItems,
+        cursor: null,
+      });
+    } else {
+      throw error;
+    }
+  }
+
+  // Enrich with related data and read status
+  const enrichedPage = await Promise.all(
+    results.page.map(async (notice: Doc<'notices'>) => {
+      // Get property info
+      const property = await ctx.db.get(notice.propertyId);
+      if (!property) throw new Error('Property not found');
+
+      // Get creator info
+      const creator = await ctx.db.get(notice.createdBy);
+      if (!creator) throw new Error('Creator not found');
+
+      // Get unit info if applicable
+      let unit = undefined;
+      if (notice.unitId) {
+        const unitData = await ctx.db.get(notice.unitId);
+        if (unitData) {
+          unit = {
+            _id: unitData._id,
+            unitNumber: unitData.unitNumber,
+          };
+        }
+      }
+
+      // Check if user has acknowledged this notice
+      const acknowledgment = await ctx.db
+        .query('noticeAcknowledgments')
+        .withIndex('by_notice_user', q => q.eq('noticeId', notice._id).eq('userId', currentUser._id))
+        .unique();
+
+      const isRead = !!acknowledgment;
+      const acknowledgedAt = acknowledgment?.acknowledgedAt;
+
+      return {
+        ...notice,
+        isRead,
+        acknowledgedAt,
+        property: {
+          _id: property._id,
+          name: property.name,
+          address: property.address,
+        },
+        creator: {
+          _id: creator._id,
+          firstName: creator.firstName,
+          lastName: creator.lastName,
+        },
+        unit,
+      };
+    })
+  );
+
+  // Apply read status filter
+  let filteredPage = enrichedPage;
+  if (args.isRead !== undefined) {
+    filteredPage = enrichedPage.filter(notice => notice.isRead === args.isRead);
+  }
+
+  // Apply search filter if provided
+  if (args.search) {
+    const searchTerm = args.search.toLowerCase();
+    filteredPage = filteredPage.filter(
+      notice => notice.title.toLowerCase().includes(searchTerm) || notice.content.toLowerCase().includes(searchTerm)
+    );
+  }
+
+  return {
+    page: filteredPage,
+    isDone: results.isDone,
+    continueCursor: results.continueCursor,
+  };
+};

--- a/convex/seeders/notice.ts
+++ b/convex/seeders/notice.ts
@@ -1,0 +1,396 @@
+import { mutation } from '../_generated/server';
+import { v } from 'convex/values';
+
+export const seedNotices = mutation({
+  args: {},
+  returns: v.object({
+    notices: v.number(),
+    events: v.number(),
+    polls: v.number(),
+    acknowledgments: v.number(),
+  }),
+  handler: async ctx => {
+    // Get existing data to seed notices
+    const existingUser = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', q => q.eq('clerkId', 'user_32msooiDCcy4XFaNVVRL3wIlIg1'))
+      .unique();
+
+    if (!existingUser) {
+      throw new Error('Manager user not found. Please run the main seed first.');
+    }
+
+    const properties = await ctx.db.query('properties').collect();
+    if (properties.length === 0) {
+      throw new Error('No properties found. Please run the main seed first.');
+    }
+
+    const tenants = await ctx.db
+      .query('users')
+      .filter(q => q.eq(q.field('role'), 'tenant'))
+      .collect();
+    const units = await ctx.db
+      .query('units')
+      .filter(q => q.eq(q.field('isOccupied'), true))
+      .collect();
+
+    let noticesCount = 0;
+    let eventsCount = 0;
+    let pollsCount = 0;
+    let acknowledgmentsCount = 0;
+
+    // Helper function to get random items from array
+    const getRandomItems = <T>(array: T[], count: number): T[] => {
+      const shuffled = [...array].sort(() => 0.5 - Math.random());
+      return shuffled.slice(0, count);
+    };
+
+    // Helper function to get random item from array
+    const getRandomItem = <T>(array: T[]): T => {
+      return array[Math.floor(Math.random() * array.length)];
+    };
+
+    // Create property-wide announcements
+    const announcements = [
+      {
+        title: 'Welcome to Sunset Apartments!',
+        content:
+          "Welcome to your new home! We're excited to have you as part of our community. Please take a moment to review our community guidelines and get to know your neighbors.",
+        noticeType: 'announcement',
+        priority: 'low',
+        targetAudience: 'all',
+      },
+      {
+        title: 'Holiday Decorating Contest',
+        content:
+          'Show off your holiday spirit! Decorate your unit and enter our annual holiday decorating contest. Winner receives a $100 gift card and bragging rights!',
+        noticeType: 'announcement',
+        priority: 'medium',
+        targetAudience: 'tenants',
+      },
+      {
+        title: 'Community Garden Update',
+        content:
+          'The community garden maintenance is now complete. All garden areas are open and ready for planting. Seeds and tools are available in the lobby.',
+        noticeType: 'announcement',
+        priority: 'low',
+        targetAudience: 'all',
+      },
+      {
+        title: 'Fitness Center Renovation',
+        content:
+          'Our fitness center will be closed for renovations starting next Monday. We expect to reopen in two weeks with brand new equipment!',
+        noticeType: 'maintenance',
+        priority: 'medium',
+        targetAudience: 'tenants',
+      },
+    ];
+
+    // Create property notices
+    for (const property of properties) {
+      for (const announcement of announcements) {
+        const noticeId = await ctx.db.insert('notices', {
+          propertyId: property._id,
+          createdBy: existingUser._id,
+          title: announcement.title,
+          content: announcement.content,
+          noticeType: announcement.noticeType,
+          priority: announcement.priority,
+          targetAudience: announcement.targetAudience,
+          targetUnits: undefined,
+          isActive: true,
+          scheduledAt: undefined,
+          expiresAt: undefined,
+          attachments: [],
+          createdAt: Date.now() - Math.random() * 7 * 24 * 60 * 60 * 1000, // Random time within last week
+          updatedAt: Date.now(),
+        });
+        noticesCount++;
+
+        // Create some acknowledgments for recent notices
+        if (Math.random() > 0.5) {
+          const noticeTenants = tenants.filter(t => Math.random() > 0.7);
+          for (const tenant of noticeTenants) {
+            await ctx.db.insert('noticeAcknowledgments', {
+              noticeId,
+              userId: tenant._id,
+              acknowledgedAt: Date.now() - Math.random() * 24 * 60 * 60 * 1000, // Random time within last day
+            });
+            acknowledgmentsCount++;
+          }
+        }
+      }
+
+      // Create payment reminders
+      const paymentReminders = [
+        {
+          title: 'Rent Payment Due',
+          content:
+            'Your monthly rent payment is due in 3 days. Please ensure payment is made by the due date to avoid late fees.',
+          noticeType: 'payment_reminder',
+          priority: 'high',
+          targetAudience: 'tenants',
+        },
+        {
+          title: 'Parking Fee Reminder',
+          content:
+            'Monthly parking fees are due this Friday. Reserved parking spots are assigned on a first-come, first-served basis.',
+          noticeType: 'payment_reminder',
+          priority: 'medium',
+          targetAudience: 'tenants',
+        },
+      ];
+
+      for (const reminder of paymentReminders) {
+        const noticeId = await ctx.db.insert('notices', {
+          propertyId: property._id,
+          createdBy: existingUser._id,
+          title: reminder.title,
+          content: reminder.content,
+          noticeType: reminder.noticeType,
+          priority: reminder.priority,
+          targetAudience: reminder.targetAudience,
+          targetUnits: undefined,
+          isActive: true,
+          scheduledAt: undefined,
+          expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000, // Expires in 1 week
+          attachments: [],
+          createdAt: Date.now() - Math.random() * 3 * 24 * 60 * 60 * 1000, // Random time within last 3 days
+          updatedAt: Date.now(),
+        });
+        noticesCount++;
+      }
+
+      // Create emergency notices
+      const emergencies = [
+        {
+          title: 'Emergency Maintenance - Water Main Break',
+          content:
+            'Due to a water main break in the area, water service may be intermittent for the next few hours. Please conserve water and report any issues.',
+          noticeType: 'emergency',
+          priority: 'urgent',
+          targetAudience: 'all',
+        },
+        {
+          title: 'Fire Alarm Test',
+          content:
+            'Monthly fire alarm test scheduled for tomorrow at 10 AM. You will hear a series of beeps. This is a test - no action required.',
+          noticeType: 'emergency',
+          priority: 'medium',
+          targetAudience: 'all',
+        },
+      ];
+
+      for (const emergency of emergencies) {
+        const noticeId = await ctx.db.insert('notices', {
+          propertyId: property._id,
+          createdBy: existingUser._id,
+          title: emergency.title,
+          content: emergency.content,
+          noticeType: emergency.noticeType,
+          priority: emergency.priority,
+          targetAudience: emergency.targetAudience,
+          targetUnits: undefined,
+          isActive: true,
+          scheduledAt: undefined,
+          expiresAt: Date.now() + 24 * 60 * 60 * 1000, // Expires in 24 hours
+          attachments: [],
+          createdAt: Date.now() - Math.random() * 24 * 60 * 60 * 1000, // Random time within last day
+          updatedAt: Date.now(),
+        });
+        noticesCount++;
+      }
+    }
+
+    // Create events
+    const events = [
+      {
+        title: 'Community Potluck Dinner',
+        description:
+          'Join us for our monthly community potluck! Bring your favorite dish and meet your neighbors. Location: Community Room.',
+        eventType: 'community',
+        startDate: Date.now() + 7 * 24 * 60 * 60 * 1000, // Next week
+        endDate: Date.now() + 7 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000, // 3 hours later
+        location: 'Community Room',
+        isRecurring: false,
+        maxAttendees: 50,
+        isPublic: true,
+      },
+      {
+        title: 'Fitness Class - Yoga',
+        description: 'Free yoga class for all residents. Bring your own mat. Beginner-friendly session.',
+        eventType: 'social',
+        startDate: Date.now() + 3 * 24 * 60 * 60 * 1000, // In 3 days
+        endDate: Date.now() + 3 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000, // 1 hour later
+        location: 'Fitness Center',
+        isRecurring: true,
+        maxAttendees: 20,
+        isPublic: true,
+      },
+      {
+        title: 'Board Meeting',
+        description: 'Monthly board meeting to discuss property matters and community concerns.',
+        eventType: 'meeting',
+        startDate: Date.now() + 14 * 24 * 60 * 60 * 1000, // In 2 weeks
+        endDate: Date.now() + 14 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000, // 2 hours later
+        location: 'Conference Room',
+        isRecurring: true,
+        maxAttendees: undefined,
+        isPublic: false,
+      },
+      {
+        title: 'Elevator Maintenance',
+        description:
+          'Scheduled maintenance on Building A elevators. Elevators will be out of service from 10 PM to 6 AM.',
+        eventType: 'maintenance',
+        startDate: Date.now() + 2 * 24 * 60 * 60 * 1000, // In 2 days at 10 PM
+        endDate: Date.now() + 2 * 24 * 60 * 60 * 1000 + 8 * 60 * 60 * 1000, // 8 hours later
+        location: 'Building A',
+        isRecurring: false,
+        maxAttendees: undefined,
+        isPublic: true,
+      },
+    ];
+
+    for (const property of properties) {
+      for (const event of events) {
+        const eventId = await ctx.db.insert('events', {
+          propertyId: property._id,
+          createdBy: existingUser._id,
+          title: event.title,
+          description: event.description,
+          eventType: event.eventType,
+          startDate: event.startDate,
+          endDate: event.endDate,
+          location: event.location,
+          isRecurring: event.isRecurring,
+          recurringPattern: event.isRecurring ? 'monthly' : undefined,
+          maxAttendees: event.maxAttendees,
+          isPublic: event.isPublic,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+        eventsCount++;
+
+        // Create some event RSVPs
+        if (event.isPublic) {
+          const rsvpTenants = getRandomItems(tenants, Math.min(tenants.length, event.maxAttendees || 10));
+          for (const tenant of rsvpTenants) {
+            const status = Math.random() > 0.3 ? 'attending' : Math.random() > 0.5 ? 'maybe' : 'declined';
+            await ctx.db.insert('eventAttendees', {
+              eventId,
+              userId: tenant._id,
+              status,
+              registeredAt: Date.now() - Math.random() * 24 * 60 * 60 * 1000,
+            });
+          }
+        }
+      }
+    }
+
+    // Create polls
+    const polls = [
+      {
+        title: 'Property Improvement Survey',
+        description: "Help us improve our property! Tell us what amenities you'd like to see added.",
+        question: 'Which amenity would you most like to see added to the property?',
+        options: ['Rooftop Garden', 'Additional Parking', 'Swimming Pool', 'Community Theater', 'Pet Park'],
+        pollType: 'single_choice',
+        isActive: true,
+        allowAnonymous: false,
+        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000, // 1 week
+      },
+      {
+        title: 'Noise Policy Feedback',
+        description: "We're reviewing our noise policy. Your input helps us maintain a comfortable living environment.",
+        question: 'What are your thoughts on quiet hours?',
+        options: ['Current hours are perfect', 'Should start earlier', 'Should end later', 'Need more enforcement'],
+        pollType: 'multiple_choice',
+        isActive: true,
+        allowAnonymous: true,
+        expiresAt: Date.now() + 14 * 24 * 60 * 60 * 1000, // 2 weeks
+      },
+      {
+        title: 'Holiday Decorations',
+        description: 'Share your thoughts on holiday decorations this year.',
+        question: 'How would you rate our holiday decorations?',
+        options: ['1', '2', '3', '4', '5'],
+        pollType: 'rating',
+        isActive: true,
+        allowAnonymous: false,
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000, // 30 days
+      },
+      {
+        title: 'Maintenance Satisfaction',
+        description: 'How satisfied are you with our maintenance response times?',
+        question: 'Please share any additional feedback about maintenance services.',
+        options: [],
+        pollType: 'text',
+        isActive: true,
+        allowAnonymous: false,
+        expiresAt: Date.now() + 21 * 24 * 60 * 60 * 1000, // 3 weeks
+      },
+    ];
+
+    for (const property of properties) {
+      for (const poll of polls) {
+        const pollId = await ctx.db.insert('polls', {
+          propertyId: property._id,
+          createdBy: existingUser._id,
+          title: poll.title,
+          description: poll.description,
+          question: poll.question,
+          options: poll.options,
+          pollType: poll.pollType,
+          isActive: poll.isActive,
+          allowAnonymous: poll.allowAnonymous,
+          expiresAt: poll.expiresAt,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+        pollsCount++;
+
+        // Create some poll responses
+        const responseTenants = getRandomItems(tenants, Math.floor(tenants.length * 0.6)); // 60% response rate
+        for (const tenant of responseTenants) {
+          let selectedOptions: number[] = [];
+          let textResponse: string | undefined;
+
+          if (poll.pollType === 'single_choice' || poll.pollType === 'rating') {
+            selectedOptions = [Math.floor(Math.random() * poll.options.length)];
+          } else if (poll.pollType === 'multiple_choice') {
+            const numOptions = Math.floor(Math.random() * poll.options.length) + 1;
+            selectedOptions = getRandomItems(
+              Array.from({ length: poll.options.length }, (_, i) => i),
+              numOptions
+            );
+          } else if (poll.pollType === 'text') {
+            const responses = [
+              'Very satisfied with the quick response times!',
+              'Could be faster during peak hours.',
+              'Excellent service overall.',
+              'Need better communication about maintenance schedules.',
+              'Staff is very professional and helpful.',
+            ];
+            textResponse = getRandomItem(responses);
+          }
+
+          await ctx.db.insert('pollResponses', {
+            pollId,
+            userId: poll.allowAnonymous && Math.random() > 0.5 ? undefined : tenant._id,
+            selectedOptions,
+            textResponse,
+            submittedAt: Date.now() - Math.random() * 3 * 24 * 60 * 60 * 1000, // Random time within last 3 days
+          });
+        }
+      }
+    }
+
+    return {
+      notices: noticesCount,
+      events: eventsCount,
+      polls: pollsCount,
+      acknowledgments: acknowledgmentsCount,
+    };
+  },
+});

--- a/convex/seeders/seed.ts
+++ b/convex/seeders/seed.ts
@@ -1,5 +1,7 @@
+import { Id } from '../_generated/dataModel';
 import { mutation } from '../_generated/server';
 import { v } from 'convex/values';
+import { api } from '../_generated/api';
 
 export const seedDatabase = mutation({
   args: {},
@@ -8,11 +10,25 @@ export const seedDatabase = mutation({
     units: v.number(),
     users: v.number(),
     maintenanceRequests: v.number(),
+    notices: v.number(),
+    events: v.number(),
+    polls: v.number(),
+    acknowledgments: v.number(),
   }),
-  handler: async ctx => {
-    // Your existing user data
-    const existingUser = {
-      _id: 'nd7bajzdm6w24wr8gmwctayysn7qp1hn' as any,
+  handler: async (
+    ctx
+  ): Promise<{
+    properties: number;
+    units: number;
+    users: number;
+    maintenanceRequests: number;
+    notices: number;
+    events: number;
+    polls: number;
+    acknowledgments: number;
+  }> => {
+    // Create the manager user first
+    const managerId = await ctx.db.insert('users', {
       clerkId: 'user_32msooiDCcy4XFaNVVRL3wIlIg1',
       email: 'meatole.cs@gmail.com',
       firstName: 'Martin Edgar',
@@ -24,7 +40,7 @@ export const seedDatabase = mutation({
       createdAt: Date.now(),
       updatedAt: Date.now(),
       lastLoginAt: Date.now(),
-    };
+    });
 
     // Create properties
     const property1Id = await ctx.db.insert('properties', {
@@ -36,7 +52,7 @@ export const seedDatabase = mutation({
       country: 'USA',
       propertyType: 'apartment',
       totalUnits: 50,
-      managerId: existingUser._id,
+      managerId: managerId,
       isActive: true,
       settings: {
         visitorLimitPerUnit: 2,
@@ -53,7 +69,7 @@ export const seedDatabase = mutation({
       updatedAt: Date.now(),
     });
 
-    const property2Id = await ctx.db.insert('properties', {
+    await ctx.db.insert('properties', {
       name: 'Downtown Plaza',
       address: '456 Oak Avenue',
       city: 'San Francisco',
@@ -62,7 +78,7 @@ export const seedDatabase = mutation({
       country: 'USA',
       propertyType: 'condo',
       totalUnits: 30,
-      managerId: existingUser._id,
+      managerId: managerId,
       isActive: true,
       settings: {
         visitorLimitPerUnit: 3,
@@ -421,11 +437,23 @@ export const seedDatabase = mutation({
       maintenanceRequestIds.push(id);
     }
 
+    // Seed notices, events, and polls
+    const noticeResults: {
+      notices: number;
+      events: number;
+      polls: number;
+      acknowledgments: number;
+    } = await ctx.runMutation(api.seeders.notice.seedNotices);
+
     return {
       properties: 2,
       units: 10,
-      users: 5, // 1 manager + 3 tenants + 2 technicians
+      users: 6, // 1 manager + 3 tenants + 2 technicians
       maintenanceRequests: 10,
+      notices: noticeResults.notices,
+      events: noticeResults.events,
+      polls: noticeResults.polls,
+      acknowledgments: noticeResults.acknowledgments,
     };
   },
 });

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,225 +1,615 @@
-import { Image, Text, useWindowDimensions } from 'react-native';
-import Carousel from 'react-native-reanimated-carousel';
-import { Ionicons } from '@expo/vector-icons';
+import { Text as RNText, TouchableOpacity, ScrollView, RefreshControl, Alert, Animated } from 'react-native';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@convex/_generated/api';
+import { Ionicons, MaterialIcons, FontAwesome5 } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useState, useCallback } from 'react';
 
-import ParallaxScrollView from '@/components/parallax-scroll-view';
-import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
-
-// Carousel data
-const carouselData = [
-  require('@/assets/images/carousel/carousel-image-1.png'),
-  require('@/assets/images/carousel/carousel-image-2.jpeg'),
-  require('@/assets/images/carousel/carousel-image-3.jpeg'),
-  require('@/assets/images/carousel/carousel-image-4.jpeg'),
-  require('@/assets/images/carousel/carousel-image-5.jpeg'),
-];
-
-// Mock data for digital noticeboard
-const mockAnnouncements = [
-  {
-    id: 1,
-    title: 'Community Garden Maintenance',
-    message:
-      'The community garden will be closed for maintenance this Saturday from 9 AM to 12 PM. Please plan accordingly.',
-    date: '2024-12-15',
-    priority: 'normal',
-  },
-  {
-    id: 2,
-    title: 'Holiday Lighting Contest',
-    message:
-      'Show off your holiday spirit! Decorate your unit and enter our holiday lighting contest. Winner announced December 20th.',
-    date: '2024-12-10',
-    priority: 'normal',
-  },
-];
-
-const mockPaymentReminders = [
-  {
-    id: 1,
-    tenant: 'Unit 2B - Sarah Johnson',
-    amount: '$1,250.00',
-    dueDate: '2024-12-20',
-    status: 'overdue',
-    daysOverdue: 3,
-  },
-  {
-    id: 2,
-    tenant: 'Unit 3A - Michael Chen',
-    amount: '$950.00',
-    dueDate: '2024-12-25',
-    status: 'pending',
-    daysOverdue: 0,
-  },
-];
-
-const mockUrgentAlerts = [
-  {
-    id: 1,
-    title: 'Power Outage - Building A',
-    message: 'Scheduled power maintenance in Building A tonight from 10 PM to 2 AM. Elevators will be out of service.',
-    severity: 'warning',
-    timestamp: '2024-12-15T18:30:00Z',
-  },
-  {
-    id: 2,
-    title: 'Parking Lot Closure',
-    message: 'Visitor parking lot will be closed tomorrow for resurfacing. Please use alternate parking areas.',
-    severity: 'info',
-    timestamp: '2024-12-15T16:00:00Z',
-  },
-];
+import { Text } from '@/components/ui/text';
+import { Id } from '@convex/_generated/dataModel';
 
 export default function HomeScreen() {
-  const { width } = useWindowDimensions();
+  const [refreshing, setRefreshing] = useState(false);
+  const [selectedPollOptions, setSelectedPollOptions] = useState<{ [pollId: string]: number[] }>({});
+  const [readAnimations, setReadAnimations] = useState<{ [noticeId: string]: Animated.Value }>({});
+  const [animatingNotices, setAnimatingNotices] = useState<Set<string>>(new Set());
+  const [acknowledgedNotices, setAcknowledgedNotices] = useState<Set<string>>(new Set());
+  const [eventRSVPStatus, setEventRSVPStatus] = useState<{ [eventId: string]: 'attending' | 'maybe' | 'declined' }>({});
 
-  const renderCarouselItem = ({ item }: { item: any }) => (
-    <Image source={item} className='w-full h-60' resizeMode='cover' />
-  );
+  // Noticeboard data queries
+  const notices = useQuery(api.noticeboard.mobileGetNotices, {
+    paginationOpts: { numItems: 10, cursor: null },
+  });
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+  const communityNews = useQuery(api.noticeboard.mobileGetCommunityNews, {
+    paginationOpts: { numItems: 8, cursor: null },
+  });
+
+  const events = useQuery(api.noticeboard.mobileGetEvents, {
+    paginationOpts: { numItems: 5, cursor: null },
+  });
+
+  // Use a stable key to ensure consistent query identity
+  const activePolls = useQuery(api.noticeboard.mobileGetActivePolls, {
+    paginationOpts: { numItems: 5, cursor: null },
+  });
+
+  // Mutations
+  const acknowledgeNotice = useMutation(api.noticeboard.mobileAcknowledgeNotice);
+  const addEventToCalendar = useMutation(api.noticeboard.mobileAddEventToCalendar);
+  const submitPollResponse = useMutation(api.noticeboard.mobileSubmitPollResponse);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    // Clear local state to sync with fresh data
+    setAcknowledgedNotices(new Set());
+    setEventRSVPStatus({});
+    // Invalidate queries and refetch
+    setTimeout(() => setRefreshing(false), 1000);
+  }, []);
+
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp).toLocaleDateString('en-US', {
       weekday: 'short',
       month: 'short',
       day: 'numeric',
     });
   };
 
-  const getSeverityColor = (severity: string) => {
-    switch (severity) {
-      case 'warning':
-        return '#FF6B35';
-      case 'info':
-        return '#4A90E2';
+  const formatTime = (timestamp: number) => {
+    return new Date(timestamp).toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  };
+
+  const getPriorityColor = (priority: string) => {
+    switch (priority) {
+      case 'urgent':
+        return '#EF4444';
+      case 'high':
+        return '#F97316';
+      case 'medium':
+        return '#F59E0B';
+      case 'low':
+        return '#10B981';
       default:
-        return '#666';
+        return '#6B7280';
     }
   };
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'overdue':
-        return '#E74C3C';
-      case 'pending':
-        return '#F39C12';
+  const getEventTypeIcon = (eventType: string) => {
+    switch (eventType) {
+      case 'community':
+        return 'users';
+      case 'maintenance':
+        return 'tools';
+      case 'meeting':
+        return 'user-friends';
+      case 'social':
+        return 'glass-cheers';
+      case 'emergency':
+        return 'exclamation-triangle';
       default:
-        return '#27AE60';
+        return 'calendar';
     }
   };
+
+  const handleAcknowledgeNotice = async (noticeId: string) => {
+    console.log('Attempting to acknowledge notice:', noticeId);
+    try {
+      const result = await acknowledgeNotice({ noticeId: noticeId as Id<'notices'> });
+      console.log('Acknowledgment result:', result);
+
+      // Immediately update local state to show checkmark
+      setAcknowledgedNotices(prev => new Set(prev).add(noticeId));
+
+      // Start read animation
+      setAnimatingNotices(prev => new Set(prev).add(noticeId));
+      const animation = new Animated.Value(0);
+      setReadAnimations(prev => ({ ...prev, [noticeId]: animation }));
+
+      Animated.sequence([
+        Animated.timing(animation, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+        Animated.delay(500),
+        Animated.timing(animation, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start(() => {
+        setAnimatingNotices(prev => {
+          const newSet = new Set(prev);
+          newSet.delete(noticeId);
+          return newSet;
+        });
+      });
+    } catch (error) {
+      console.error('Error acknowledging notice:', error);
+      Alert.alert('Error', 'Failed to acknowledge notice');
+    }
+  };
+
+  const handleRSVP = async (eventId: string, status: 'attending' | 'maybe' | 'declined') => {
+    try {
+      const result = await addEventToCalendar({ eventId: eventId as Id<'events'>, status });
+      console.log('RSVP result:', result);
+
+      // Immediately update local state to show new RSVP status
+      setEventRSVPStatus(prev => ({ ...prev, [eventId]: status }));
+
+      const statusText = status === 'attending' ? 'attending' : status === 'maybe' ? 'maybe attending' : 'declining';
+      Alert.alert('Success', `You've marked yourself as ${statusText}`);
+    } catch (error) {
+      console.error('Error updating RSVP:', error);
+      Alert.alert('Error', 'Failed to update RSVP status');
+    }
+  };
+
+  const handlePollOptionSelect = (pollId: string, optionIndex: number, pollType: string) => {
+    setSelectedPollOptions(prev => {
+      const current = prev[pollId] || [];
+      if (pollType === 'single_choice') {
+        return { ...prev, [pollId]: [optionIndex] };
+      } else if (pollType === 'multiple_choice') {
+        const newSelection = current.includes(optionIndex)
+          ? current.filter(idx => idx !== optionIndex)
+          : [...current, optionIndex];
+        return { ...prev, [pollId]: newSelection };
+      } else if (pollType === 'rating') {
+        return { ...prev, [pollId]: [optionIndex] };
+      }
+      return prev;
+    });
+  };
+
+  const handlePollSubmit = async (pollId: string) => {
+    const selectedOptions = selectedPollOptions[pollId] || [];
+    if (selectedOptions.length === 0) {
+      Alert.alert('Error', 'Please select an option');
+      return;
+    }
+
+    try {
+      await submitPollResponse({ pollId: pollId as Id<'polls'>, selectedOptions });
+      Alert.alert('Success', 'Poll response submitted');
+      // Clear selection after successful submission
+      setSelectedPollOptions(prev => ({ ...prev, [pollId]: [] }));
+    } catch {
+      Alert.alert('Error', 'Failed to submit poll response');
+    }
+  };
+
+  const renderHeroSection = () => (
+    <LinearGradient colors={['#3B82F6', '#1D4ED8', '#1E40AF']} className='h-32 justify-end pb-4 px-4 rounded-b-3xl'>
+      <RNText className='text-3xl font-bold text-white mb-0.5'>Welcome to Inventi</RNText>
+      <RNText className='text-white/80 text-xs'>Your digital property noticeboard</RNText>
+    </LinearGradient>
+  );
+
+  const renderNoticeCard = (notice: any) => {
+    const isAnimating = animatingNotices.has(notice._id);
+    const animation = readAnimations[notice._id];
+    const isAcknowledged = notice.isRead || acknowledgedNotices.has(notice._id);
+
+    return (
+      <TouchableOpacity
+        key={notice._id}
+        className='bg-white rounded-xl p-3 mb-3 shadow-sm border border-gray-100'
+        onPress={() => {
+          console.log('Notice card clicked:', notice._id, 'isRead:', notice.isRead);
+          if (!isAcknowledged) {
+            handleAcknowledgeNotice(notice._id);
+          } else {
+            console.log('Notice already read, no action taken');
+          }
+        }}
+      >
+        <ThemedView className='flex-row items-start justify-between mb-2'>
+          <ThemedView className='flex-row items-center flex-1'>
+            <ThemedView
+              className='w-1.5 h-1.5 rounded-full mr-2'
+              style={{ backgroundColor: getPriorityColor(notice.priority) }}
+            />
+            <Text className='text-sm font-semibold text-gray-900 flex-1' numberOfLines={2}>
+              {notice.title}
+            </Text>
+          </ThemedView>
+          {(isAcknowledged || isAnimating) && (
+            <Animated.View
+              style={{
+                transform: [
+                  {
+                    scale: animation
+                      ? animation.interpolate({
+                          inputRange: [0, 0.5, 1],
+                          outputRange: [0, 1.2, 1],
+                        })
+                      : 1,
+                  },
+                ],
+                opacity: animation || 1,
+              }}
+            >
+              <MaterialIcons name='check-circle' size={14} color='#10B981' />
+            </Animated.View>
+          )}
+        </ThemedView>
+
+        <Text className='text-xs text-gray-600 mb-2 leading-4' numberOfLines={2}>
+          {notice.content}
+        </Text>
+
+        <ThemedView className='flex-row items-center justify-between'>
+          <ThemedView className='flex-row items-center'>
+            <Ionicons name='location' size={10} color='#6B7280' />
+            <Text className='text-xs text-gray-500 ml-1'>{notice.property.name}</Text>
+          </ThemedView>
+          <Text className='text-xs text-gray-500'>{formatDate(notice.createdAt)}</Text>
+        </ThemedView>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderEventCard = (event: any) => {
+    // Use local state if available, otherwise fall back to server data
+    const currentRSVPStatus = eventRSVPStatus[event._id] || event.isAttending;
+
+    return (
+      <ThemedView key={event._id} className='bg-white rounded-xl p-3 mb-3 shadow-sm border border-gray-100'>
+        <ThemedView className='flex-row items-start justify-between mb-2'>
+          <ThemedView className='flex-row items-center flex-1'>
+            <ThemedView className='w-6 h-6 rounded-full bg-blue-100 items-center justify-center mr-2'>
+              <FontAwesome5 name={getEventTypeIcon(event.eventType)} size={12} color='#3B82F6' />
+            </ThemedView>
+            <ThemedView className='flex-1'>
+              <Text className='text-sm font-semibold text-gray-900' numberOfLines={2}>
+                {event.title}
+              </Text>
+              <Text className='text-xs text-gray-600 mt-0.5' numberOfLines={1}>
+                {event.description}
+              </Text>
+            </ThemedView>
+          </ThemedView>
+        </ThemedView>
+
+        <ThemedView className='flex-row items-center justify-between mb-2'>
+          <ThemedView className='flex-row items-center'>
+            <Ionicons name='calendar' size={12} color='#6B7280' />
+            <Text className='text-xs text-gray-500 ml-1'>
+              {formatDate(event.startDate)} • {formatTime(event.startDate)}
+            </Text>
+          </ThemedView>
+          <ThemedView className='flex-row items-center'>
+            <Ionicons name='people' size={12} color='#6B7280' />
+            <Text className='text-xs text-gray-500 ml-1'>
+              {event.attendeeCount}/{event.maxAttendees || '∞'}
+            </Text>
+          </ThemedView>
+        </ThemedView>
+
+        {event.location && (
+          <ThemedView className='flex-row items-center mb-2'>
+            <Ionicons name='location' size={12} color='#6B7280' />
+            <Text className='text-xs text-gray-500 ml-1'>{event.location}</Text>
+          </ThemedView>
+        )}
+
+        <ThemedView className='flex-row gap-1'>
+          <TouchableOpacity
+            className={`flex-1 py-1.5 px-2 rounded-md ${currentRSVPStatus === 'attending' ? 'bg-green-100' : 'bg-gray-100'}`}
+            onPress={() => handleRSVP(event._id, 'attending')}
+            disabled={event.isFull}
+          >
+            <Text
+              className={`text-xs font-medium text-center ${currentRSVPStatus === 'attending' ? 'text-green-700' : 'text-gray-700'}`}
+            >
+              {event.isFull ? 'Full' : 'Going'}
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            className={`flex-1 py-1.5 px-2 rounded-md ${currentRSVPStatus === 'maybe' ? 'bg-yellow-100' : 'bg-gray-100'}`}
+            onPress={() => handleRSVP(event._id, 'maybe')}
+          >
+            <Text
+              className={`text-xs font-medium text-center ${currentRSVPStatus === 'maybe' ? 'text-yellow-700' : 'text-gray-700'}`}
+            >
+              Maybe
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            className={`flex-1 py-1.5 px-2 rounded-md ${currentRSVPStatus === 'declined' ? 'bg-red-100' : 'bg-gray-100'}`}
+            onPress={() => handleRSVP(event._id, 'declined')}
+          >
+            <Text
+              className={`text-xs font-medium text-center ${currentRSVPStatus === 'declined' ? 'text-red-700' : 'text-gray-700'}`}
+            >
+              Decline
+            </Text>
+          </TouchableOpacity>
+        </ThemedView>
+      </ThemedView>
+    );
+  };
+
+  const renderPollCard = (poll: any) => (
+    <ThemedView key={poll._id} className='bg-white rounded-xl p-3 mb-3 shadow-sm border border-gray-100'>
+      <ThemedView className='flex-row items-start justify-between mb-2'>
+        <ThemedView className='flex-row items-center flex-1'>
+          <ThemedView className='w-6 h-6 rounded-full bg-purple-100 items-center justify-center mr-2'>
+            <Ionicons name='help-circle' size={14} color='#8B5CF6' />
+          </ThemedView>
+          <ThemedView className='flex-1'>
+            <Text className='text-sm font-semibold text-gray-900' numberOfLines={2}>
+              {poll.title}
+            </Text>
+            <Text className='text-xs text-gray-600 mt-0.5' numberOfLines={1}>
+              {poll.question}
+            </Text>
+          </ThemedView>
+        </ThemedView>
+        {poll.hasResponded && <MaterialIcons name='check-circle' size={14} color='#10B981' />}
+      </ThemedView>
+
+      {!poll.hasResponded && (
+        <ThemedView className='mb-2'>
+          {poll.pollType === 'single_choice' && (
+            <ThemedView className='space-y-1'>
+              {poll.options.map((option: string, index: number) => {
+                const isSelected = selectedPollOptions[poll._id]?.includes(index);
+                return (
+                  <TouchableOpacity
+                    key={index}
+                    className={`flex-row items-center p-2 border rounded-md ${
+                      isSelected ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
+                    }`}
+                    onPress={() => handlePollOptionSelect(poll._id, index, poll.pollType)}
+                  >
+                    <ThemedView
+                      className={`w-3 h-3 rounded-full border-2 mr-2 ${
+                        isSelected ? 'border-blue-500 bg-blue-500' : 'border-gray-300'
+                      }`}
+                    >
+                      {isSelected && <ThemedView className='w-1.5 h-1.5 bg-white rounded-full m-0.25' />}
+                    </ThemedView>
+                    <Text className={`text-xs ${isSelected ? 'text-blue-700 font-medium' : 'text-gray-700'}`}>
+                      {option}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ThemedView>
+          )}
+
+          {poll.pollType === 'multiple_choice' && (
+            <ThemedView className='space-y-1'>
+              {poll.options.map((option: string, index: number) => {
+                const isSelected = selectedPollOptions[poll._id]?.includes(index);
+                return (
+                  <TouchableOpacity
+                    key={index}
+                    className={`flex-row items-center p-2 border rounded-md ${
+                      isSelected ? 'border-purple-500 bg-purple-50' : 'border-gray-200'
+                    }`}
+                    onPress={() => handlePollOptionSelect(poll._id, index, poll.pollType)}
+                  >
+                    <ThemedView
+                      className={`w-3 h-3 border-2 mr-2 ${
+                        isSelected ? 'border-purple-500 bg-purple-500' : 'border-gray-300'
+                      }`}
+                    >
+                      {isSelected && <Ionicons name='checkmark' size={8} color='white' />}
+                    </ThemedView>
+                    <Text className={`text-xs ${isSelected ? 'text-purple-700 font-medium' : 'text-gray-700'}`}>
+                      {option}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ThemedView>
+          )}
+
+          {poll.pollType === 'rating' && (
+            <ThemedView className='flex-row justify-center space-x-1'>
+              {poll.options.map((option: string, index: number) => {
+                const isSelected = selectedPollOptions[poll._id]?.includes(index);
+                return (
+                  <TouchableOpacity
+                    key={index}
+                    className={`w-8 h-8 rounded-full border-2 items-center justify-center ${
+                      isSelected ? 'border-yellow-500 bg-yellow-100' : 'border-gray-300'
+                    }`}
+                    onPress={() => handlePollOptionSelect(poll._id, index, poll.pollType)}
+                  >
+                    <Text className={`text-xs font-medium ${isSelected ? 'text-yellow-700' : 'text-gray-500'}`}>
+                      {option}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ThemedView>
+          )}
+
+          {/* Submit Button */}
+          <TouchableOpacity
+            className='bg-blue-500 rounded-md py-1.5 px-3 mt-2 items-center'
+            onPress={() => handlePollSubmit(poll._id)}
+            disabled={!selectedPollOptions[poll._id]?.length}
+          >
+            <Text
+              className={`text-xs font-medium ${
+                selectedPollOptions[poll._id]?.length ? 'text-white' : 'text-gray-300'
+              }`}
+            >
+              Submit
+            </Text>
+          </TouchableOpacity>
+        </ThemedView>
+      )}
+
+      <ThemedView className='flex-row items-center justify-between'>
+        <Text className='text-xs text-gray-500'>{poll.responseCount} responses</Text>
+        {poll.expiresAt && (
+          <Text className='text-xs text-gray-500'>
+            {poll.isExpired
+              ? 'Expired'
+              : `${Math.ceil((poll.expiresAt - Date.now()) / (1000 * 60 * 60 * 24))} days left`}
+          </Text>
+        )}
+      </ThemedView>
+    </ThemedView>
+  );
 
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: 'transparent', dark: 'transparent' }}
-      headerImage={
-        <Carousel
-          loop
-          width={width}
-          height={250}
-          autoPlay={true}
-          data={carouselData}
-          scrollAnimationDuration={5000}
-          renderItem={renderCarouselItem}
-        />
-      }
+    <ScrollView
+      className='flex-1 bg-gray-50'
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     >
-      {/* Welcome Header */}
-      <ThemedView className='py-0 items-start'>
-        <Text className='text-3xl font-bold text-blue-800 text-left mb-2'>Welcome to Inventi App</Text>
-        <ThemedText className='text-sm text-gray-600 text-left mb-4 leading-5'>
-          Your digital noticeboard for all property updates and announcements
-        </ThemedText>
-      </ThemedView>
+      {/* Hero Section */}
+      {renderHeroSection()}
 
-      {/* Property-wide Announcements */}
-      <ThemedView className='mb-6'>
-        <ThemedView className='flex-row items-center gap-3 mb-4'>
-          <Ionicons name='megaphone' size={24} color='#4A90E2' />
-          <ThemedText type='subtitle' className='text-lg font-semibold text-gray-800'>
-            Property Announcements
-          </ThemedText>
-        </ThemedView>
-        {mockAnnouncements.map(announcement => (
-          <ThemedView key={announcement.id} className='bg-gray-50 rounded-xl p-4 mb-3 border-l-4 border-blue-800'>
-            <ThemedView className='flex-row justify-between items-center mb-2'>
-              <ThemedText type='defaultSemiBold' className='text-base text-gray-800 flex-1'>
-                {announcement.title}
-              </ThemedText>
-              <ThemedText className='text-xs text-gray-600'>{formatDate(announcement.date)}</ThemedText>
-            </ThemedView>
-            <ThemedText className='text-sm text-gray-700 leading-5'>{announcement.message}</ThemedText>
+      <ThemedView className='px-3 pb-6'>
+        {/* Community News Section */}
+        <ThemedView className='mb-4 mt-4'>
+          <ThemedView className='flex-row items-center mb-3'>
+            <Ionicons name='newspaper' size={18} color='#3B82F6' />
+            <Text className='text-base font-semibold text-gray-900 ml-2'>Community News</Text>
           </ThemedView>
-        ))}
-      </ThemedView>
-
-      {/* Payment Reminders */}
-      <ThemedView className='mb-6'>
-        <ThemedView className='flex-row items-center gap-3 mb-4'>
-          <Ionicons name='card' size={24} color='#27AE60' />
-          <ThemedText type='subtitle' className='text-lg font-semibold text-gray-800'>
-            Payment Reminders
-          </ThemedText>
+          {communityNews === undefined ? (
+            // Loading state
+            <ThemedView className='bg-white rounded-xl p-3 shadow-sm border border-gray-100 mb-3'>
+              <ThemedView className='animate-pulse'>
+                <ThemedView className='h-3 bg-gray-200 rounded w-3/4 mb-2'></ThemedView>
+                <ThemedView className='h-2 bg-gray-200 rounded w-full mb-1'></ThemedView>
+                <ThemedView className='h-2 bg-gray-200 rounded w-2/3'></ThemedView>
+              </ThemedView>
+            </ThemedView>
+          ) : communityNews?.page && communityNews.page.length > 0 ? (
+            communityNews.page.slice(0, 3).map(renderNoticeCard)
+          ) : (
+            <ThemedView className='bg-white rounded-xl p-4 shadow-sm border border-gray-100 items-center'>
+              <Ionicons name='newspaper-outline' size={24} color='#D1D5DB' />
+              <Text className='text-gray-500 text-center mt-1 text-sm'>No community news</Text>
+            </ThemedView>
+          )}
         </ThemedView>
-        {mockPaymentReminders.map(reminder => (
-          <ThemedView
-            key={reminder.id}
-            className={`bg-gray-50 rounded-xl p-4 mb-3 border-l-4`}
-            style={{ borderLeftColor: getStatusColor(reminder.status) }}
-          >
-            <ThemedView className='flex-row justify-between items-center mb-2'>
-              <ThemedText type='defaultSemiBold' className='text-base text-gray-800 flex-1'>
-                {reminder.tenant}
-              </ThemedText>
-              <ThemedText className='text-xs font-bold' style={{ color: getStatusColor(reminder.status) }}>
-                {reminder.status.toUpperCase()}
-              </ThemedText>
-            </ThemedView>
-            <ThemedView className='flex-row justify-between items-center mb-1'>
-              <ThemedText className='text-lg font-bold text-green-600'>{reminder.amount}</ThemedText>
-              <ThemedText className='text-sm text-gray-600'>Due: {formatDate(reminder.dueDate)}</ThemedText>
-            </ThemedView>
-            {reminder.daysOverdue > 0 && (
-              <ThemedText className='text-xs text-red-600 font-bold'>{reminder.daysOverdue} days overdue</ThemedText>
-            )}
-          </ThemedView>
-        ))}
-      </ThemedView>
 
-      {/* Urgent Alerts */}
-      <ThemedView className='mb-6'>
-        <ThemedView className='flex-row items-center gap-3 mb-4'>
-          <Ionicons name='warning' size={24} color='#E74C3C' />
-          <ThemedText type='subtitle' className='text-lg font-semibold text-gray-800'>
-            Urgent Alerts
-          </ThemedText>
+        {/* Upcoming Events Section */}
+        <ThemedView className='mb-4'>
+          <ThemedView className='flex-row items-center mb-3'>
+            <Ionicons name='calendar' size={18} color='#10B981' />
+            <Text className='text-base font-semibold text-gray-900 ml-2'>Upcoming Events</Text>
+          </ThemedView>
+          {events === undefined ? (
+            // Loading state
+            <ThemedView className='bg-white rounded-xl p-3 shadow-sm border border-gray-100 mb-3'>
+              <ThemedView className='animate-pulse'>
+                <ThemedView className='flex-row items-center mb-2'>
+                  <ThemedView className='w-6 h-6 bg-gray-200 rounded-full mr-2'></ThemedView>
+                  <ThemedView className='flex-1'>
+                    <ThemedView className='h-3 bg-gray-200 rounded w-3/4 mb-1'></ThemedView>
+                    <ThemedView className='h-2 bg-gray-200 rounded w-full'></ThemedView>
+                  </ThemedView>
+                </ThemedView>
+                <ThemedView className='flex-row justify-between'>
+                  <ThemedView className='h-2 bg-gray-200 rounded w-1/3'></ThemedView>
+                  <ThemedView className='h-2 bg-gray-200 rounded w-1/4'></ThemedView>
+                </ThemedView>
+              </ThemedView>
+            </ThemedView>
+          ) : events?.page && events.page.length > 0 ? (
+            events.page.map(renderEventCard)
+          ) : (
+            <ThemedView className='bg-white rounded-xl p-4 shadow-sm border border-gray-100 items-center'>
+              <Ionicons name='calendar-outline' size={24} color='#D1D5DB' />
+              <Text className='text-gray-500 text-center mt-1 text-sm'>No upcoming events</Text>
+            </ThemedView>
+          )}
         </ThemedView>
-        {mockUrgentAlerts.map(alert => (
-          <ThemedView
-            key={alert.id}
-            className='bg-gray-50 rounded-xl p-4 mb-3 border-l-4'
-            style={{ borderLeftColor: getSeverityColor(alert.severity) }}
-          >
-            <ThemedView className='flex-row items-center gap-2 mb-2'>
-              <Ionicons
-                name={alert.severity === 'warning' ? 'warning' : 'information-circle'}
-                size={20}
-                color={getSeverityColor(alert.severity)}
-              />
-              <ThemedText type='defaultSemiBold' className='text-base text-gray-800 flex-1'>
-                {alert.title}
-              </ThemedText>
-            </ThemedView>
-            <ThemedText className='text-sm text-gray-700 leading-5 mb-2'>{alert.message}</ThemedText>
-            <ThemedText className='text-xs text-gray-600'>{new Date(alert.timestamp).toLocaleString()}</ThemedText>
-          </ThemedView>
-        ))}
-      </ThemedView>
 
-      {/* Footer */}
-      <ThemedView className='items-center py-6'>
-        <ThemedText className='text-xs text-gray-500 mb-1'>Property Management System v1.0</ThemedText>
-        <ThemedText className='text-xs text-gray-500 mb-1'>Last updated: {new Date().toLocaleDateString()}</ThemedText>
+        {/* Active Polls Section */}
+        <ThemedView className='mb-4'>
+          <ThemedView className='flex-row items-center mb-3'>
+            <Ionicons name='help-circle' size={18} color='#8B5CF6' />
+            <Text className='text-base font-semibold text-gray-900 ml-2'>Active Polls</Text>
+          </ThemedView>
+          {activePolls === undefined ? (
+            // Loading state
+            <ThemedView className='bg-white rounded-xl p-3 shadow-sm border border-gray-100 mb-3'>
+              <ThemedView className='animate-pulse'>
+                <ThemedView className='flex-row items-center mb-2'>
+                  <ThemedView className='w-6 h-6 bg-gray-200 rounded-full mr-2'></ThemedView>
+                  <ThemedView className='flex-1'>
+                    <ThemedView className='h-3 bg-gray-200 rounded w-3/4 mb-1'></ThemedView>
+                    <ThemedView className='h-2 bg-gray-200 rounded w-full'></ThemedView>
+                  </ThemedView>
+                </ThemedView>
+                <ThemedView className='flex-row space-x-1'>
+                  <ThemedView className='h-4 bg-gray-200 rounded w-12'></ThemedView>
+                  <ThemedView className='h-4 bg-gray-200 rounded w-12'></ThemedView>
+                  <ThemedView className='h-4 bg-gray-200 rounded w-12'></ThemedView>
+                </ThemedView>
+              </ThemedView>
+            </ThemedView>
+          ) : activePolls?.page && activePolls.page.length > 0 ? (
+            activePolls.page.map(renderPollCard)
+          ) : (
+            <ThemedView className='bg-white rounded-xl p-4 shadow-sm border border-gray-100 items-center'>
+              <Ionicons name='help-circle-outline' size={24} color='#D1D5DB' />
+              <Text className='text-gray-500 text-center mt-1 text-sm'>No active polls</Text>
+            </ThemedView>
+          )}
+        </ThemedView>
+
+        {/* Property Notices Section */}
+        <ThemedView className='mb-4'>
+          <ThemedView className='flex-row items-center mb-3'>
+            <Ionicons name='notifications' size={18} color='#F59E0B' />
+            <Text className='text-base font-semibold text-gray-900 ml-2'>Property Notices</Text>
+          </ThemedView>
+          {notices === undefined ? (
+            // Loading state
+            <ThemedView className='bg-white rounded-xl p-3 shadow-sm border border-gray-100 mb-3'>
+              <ThemedView className='animate-pulse'>
+                <ThemedView className='h-3 bg-gray-200 rounded w-3/4 mb-2'></ThemedView>
+                <ThemedView className='h-2 bg-gray-200 rounded w-full mb-1'></ThemedView>
+                <ThemedView className='h-2 bg-gray-200 rounded w-2/3'></ThemedView>
+              </ThemedView>
+            </ThemedView>
+          ) : notices?.page && notices.page.length > 0 ? (
+            notices.page.slice(0, 5).map(renderNoticeCard)
+          ) : (
+            <ThemedView className='bg-white rounded-xl p-4 shadow-sm border border-gray-100 items-center'>
+              <Ionicons name='notifications-outline' size={24} color='#D1D5DB' />
+              <Text className='text-gray-500 text-center mt-1 text-sm'>No property notices</Text>
+            </ThemedView>
+          )}
+        </ThemedView>
+
+        {/* Empty State - Only show if all sections are empty and not loading */}
+        {communityNews !== undefined &&
+          communityNews?.page?.length === 0 &&
+          events !== undefined &&
+          events?.page?.length === 0 &&
+          activePolls !== undefined &&
+          activePolls?.page?.length === 0 &&
+          notices !== undefined &&
+          notices?.page?.length === 0 && (
+            <ThemedView className='items-center justify-center py-12'>
+              <Ionicons name='document-text-outline' size={48} color='#D1D5DB' />
+              <Text className='text-gray-500 text-center mt-3 mb-1 text-sm'>No notices available</Text>
+              <Text className='text-gray-400 text-center text-xs'>
+                Check back later for updates from your property manager
+              </Text>
+            </ThemedView>
+          )}
       </ThemedView>
-    </ParallaxScrollView>
+    </ScrollView>
   );
 }

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -52,7 +52,7 @@ export default function SettingsScreen() {
       </View>
 
       {/* Profile Section */}
-      <ThemedView className='bg-white dark:bg-gray-800 rounded-xl p-6 mb-6 border border-gray-200 dark:border-gray-700'>
+      <ThemedView className='bg-white dark:bg-gray-800 p-6  border-gray-200 dark:border-gray-700'>
         <ThemedView className='items-center mb-6'>
           <View className='w-20 h-20 bg-blue-800 rounded-full items-center justify-center mb-4'>
             {user?.imageUrl ? (
@@ -112,7 +112,7 @@ export default function SettingsScreen() {
       </ThemedView>
 
       {/* Account Actions */}
-      <ThemedView className='bg-white dark:bg-gray-800 rounded-xl p-6 mb-6 border border-gray-200 dark:border-gray-700'>
+      <ThemedView className='bg-white dark:bg-gray-800  p-6   border-gray-200 dark:border-gray-700'>
         <Text className='text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4'>Account Actions</Text>
 
         <ThemedView className='space-y-3'>
@@ -146,18 +146,18 @@ export default function SettingsScreen() {
       </ThemedView>
 
       {/* App Info */}
-      <ThemedView className='bg-white dark:bg-gray-800 rounded-xl p-6 mb-6 border border-gray-200 dark:border-gray-700'>
-        <Text className='text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4'>App Information</Text>
+      <ThemedView className='bg-white dark:bg-gray-800 p-6  border-gray-200 dark:border-gray-700'>
+        <Text className='text-sm font-semibold text-gray-800 dark:text-gray-200 mb-4'>App Information</Text>
 
         <ThemedView className='space-y-3'>
           <ThemedView className='flex-row justify-between items-center py-2'>
-            <Text className='text-base text-gray-600 dark:text-gray-400'>Version</Text>
-            <Text className='text-base text-gray-800 dark:text-gray-200'>1.0.0</Text>
+            <Text className='text-xs text-gray-600 dark:text-gray-400'>Version</Text>
+            <Text className='text-xs text-gray-800 dark:text-gray-200'>1.0.0</Text>
           </ThemedView>
 
           <ThemedView className='flex-row justify-between items-center py-2'>
-            <Text className='text-base text-gray-600 dark:text-gray-400'>Build</Text>
-            <Text className='text-base text-gray-800 dark:text-gray-200'>2024.09.17</Text>
+            <Text className='text-xs text-gray-600 dark:text-gray-400'>Build</Text>
+            <Text className='text-xs text-gray-800 dark:text-gray-200'>2024.09.17</Text>
           </ThemedView>
         </ThemedView>
       </ThemedView>
@@ -168,12 +168,11 @@ export default function SettingsScreen() {
         onPress={handleSignOut}
         style={{
           backgroundColor: '#ef4444',
-          marginBottom: 32,
         }}
       />
 
       {/* Footer */}
-      <ThemedView className='items-center py-4'>
+      <ThemedView className='items-center py-4 !bg-gray-50'>
         <Text className='text-xs text-gray-500 text-center'>Inventi Property Management System</Text>
         <Text className='text-xs text-gray-500 text-center mt-1'>© 2024 All rights reserved</Text>
       </ThemedView>

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -24,6 +24,7 @@
         "expo-font": "~14.0.8",
         "expo-haptics": "~15.0.7",
         "expo-image": "~3.0.8",
+        "expo-linear-gradient": "^15.0.7",
         "expo-linking": "~8.0.8",
         "expo-router": "~6.0.6",
         "expo-secure-store": "^15.0.7",
@@ -1116,6 +1117,8 @@
     "expo-image": ["expo-image@3.0.8", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-L83fTHVjvE5hACxUXPk3dpABteI/IypeqxKMeOAAcT2eB/jbqT53ddsYKEvKAP86eoByQ7+TCtw9AOUizEtaTQ=="],
 
     "expo-keep-awake": ["expo-keep-awake@15.0.7", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-CgBNcWVPnrIVII5G54QDqoE125l+zmqR4HR8q+MQaCfHet+dYpS5vX5zii/RMayzGN4jPgA4XYIQ28ePKFjHoA=="],
+
+    "expo-linear-gradient": ["expo-linear-gradient@15.0.7", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-yF+y+9Shpr/OQFfy/wglB/0bykFMbwHBTuMRa5Of/r2P1wbkcacx8rg0JsUWkXH/rn2i2iWdubyqlxSJa3ggZA=="],
 
     "expo-linking": ["expo-linking@8.0.8", "", { "dependencies": { "expo-constants": "~18.0.8", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-MyeMcbFDKhXh4sDD1EHwd0uxFQNAc6VCrwBkNvvvufUsTYFq3glTA9Y8a+x78CPpjNqwNAamu74yIaIz7IEJyg=="],
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,7 +3,8 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --port 8081 --no-dev-client",
+    "start:web": "expo start --web",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo run:android",
     "ios": "expo run:ios",
@@ -31,6 +32,7 @@
     "expo-font": "~14.0.8",
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.8",
+    "expo-linear-gradient": "^15.0.7",
     "expo-linking": "~8.0.8",
     "expo-router": "~6.0.6",
     "expo-secure-store": "^15.0.7",


### PR DESCRIPTION
This pull request adds a comprehensive set of mobile-specific APIs to the noticeboard feature, enabling tenant users to interact with notices, events, polls, and feedback from mobile clients. It introduces new queries and mutations tailored for mobile use, implements robust access control and validation, and organizes the exports to clearly separate web and mobile logic.

Key changes include:

**Mobile Noticeboard API for Tenants:**

- Added mobile-specific queries and mutations for tenants to get notices, view notice details, acknowledge notices, fetch events, RSVP to events, get active polls, submit poll responses, send feedback, and access community news in `convex/noticeboard.ts`. These are exposed as new exported functions such as `mobileGetNotices`, `mobileAcknowledgeNotice`, etc. [[1]](diffhunk://#diff-a96521165cdd32d37492bcadef5b2b1da92c8527fd35e67975dcf9b21be0f9d9R42-R68) [[2]](diffhunk://#diff-a96521165cdd32d37492bcadef5b2b1da92c8527fd35e67975dcf9b21be0f9d9R150-R204)

**Mobile Handler Implementations:**

- Implemented `mobileAcknowledgeNoticeHandler` to allow tenants to acknowledge notices, with access checks for property and audience targeting.
- Implemented `mobileAddEventToCalendarHandler` for tenants to RSVP to events, handling capacity, event timing, and updating or creating RSVP records.
- Implemented `mobileSubmitPollResponseHandler` with validation for poll type, option selection, and duplicate responses, supporting both anonymous and identified submissions.
- Implemented `mobileSendFeedbackHandler` to let tenants send feedback to property managers, storing feedback as special notices and logging audit entries.

**Noticeboard API Organization:**

- Updated `convex/noticeboardDefinitions/index.ts` to clearly separate web and mobile queries/mutations, and to re-export mobile handlers under generic names for use in the mobile API layer.

**Maintenance API Cleanup:**

- Removed an unused export of `seedDatabase` from `convex/maintenance.ts` for clarity and maintainability. [[1]](diffhunk://#diff-abda0fd5c86307d4c05399fb9037378d7f1902266f00b0deaf09ecc703818d1eL34-L35) [[2]](diffhunk://#diff-abda0fd5c86307d4c05399fb9037378d7f1902266f00b0deaf09ecc703818d1eL99-L100)